### PR TITLE
Fix the container image and split the publish workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,51 @@
+name: Publish container image
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  docker:
+    name: Build & push image
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # latest=auto → `latest` is applied on non-prerelease semver tags
+          flavor: latest=auto
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,20 +1,16 @@
-name: Publish
+name: Publish to PyPI
 
 on:
   push:
     tags:
       - "v*"
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
 
   pypi:
-    name: Publish to PyPI
+    name: Build & publish
     needs: ci
     runs-on: ubuntu-latest
     environment:
@@ -39,39 +35,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-
-  docker:
-    name: Build & push Docker image
-    needs: ci
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,51 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim AS builder
+ARG PYTHON_VERSION=3.12
+ARG UV_VERSION=0.9.28
+
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
+# --- Build stage ---
+FROM python:${PYTHON_VERSION}-slim AS builder
 
 WORKDIR /app
+COPY --from=uv /uv /usr/local/bin/uv
 
-# Install uv for fast package installation
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+ENV UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never
 
-# Copy dependency files first for caching
+# 1. Library dependencies — cached on the lockfile
 COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
 
-# Install dependencies (no dev deps in production)
-RUN uv sync --no-dev --no-install-project
-
-# Copy the package source
+# 2. The library itself, installed non-editable so it lands in site-packages
 COPY markowizard/ markowizard/
-COPY backend/ backend/
-COPY frontend/ frontend/
-COPY README.md .
+COPY README.md ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-editable
 
-# Build and install the package
-RUN uv sync --no-dev
+# 3. Web-server dependencies (not part of the published library)
+COPY backend/requirements.txt ./backend/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python /app/.venv/bin/python -r backend/requirements.txt
 
 # --- Runtime stage ---
-FROM python:3.12-slim
+FROM python:${PYTHON_VERSION}-slim
 
 WORKDIR /app
+RUN groupadd --system app && useradd --system --gid app --home-dir /app app
 
-# Copy venv from builder
-COPY --from=builder /app/.venv /app/.venv
-
-# Copy frontend and backend
-COPY --from=builder /app/frontend /app/frontend
-COPY --from=builder /app/backend /app/backend
+COPY --from=builder --chown=app:app /app/.venv /app/.venv
+COPY --chown=app:app backend/ ./backend/
+COPY --chown=app:app frontend/ ./frontend/
 
 ENV PATH="/app/.venv/bin:$PATH" \
-    PYTHONUNBUFFERED=1 \
-    HOST=0.0.0.0 \
-    PORT=8000
+    PYTHONUNBUFFERED=1
 
+USER app
 EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health', timeout=2)"
 
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,17 +1,21 @@
 # Releasing
 
-Pushing a `v*` tag triggers `.github/workflows/python-publish.yml`, which — after
-CI passes — builds and publishes the PyPI package and the GHCR container image.
+Pushing a `v*` tag triggers two workflows, each gated on CI:
+
+| Workflow | Publishes |
+| --- | --- |
+| `.github/workflows/python-publish.yml` | `markowizard` to PyPI |
+| `.github/workflows/docker-publish.yml` | `ghcr.io/outliersanalytics/markowizard` image |
 
 ## One-time setup
 
 ### PyPI trusted publisher
 
-The workflow publishes with [trusted publishing](https://docs.pypi.org/trusted-publishers/)
+The PyPI workflow publishes with [trusted publishing](https://docs.pypi.org/trusted-publishers/)
 (OIDC, no API token). Before the first release, register the publisher on PyPI:
 
 1. Go to <https://pypi.org/manage/account/publishing/>.
-2. Add a **pending publisher** (the project doesn't exist on PyPI yet):
+2. Add a **pending publisher**:
    - PyPI project name: `markowizard`
    - Owner: `OutliersAnalytics`
    - Repository name: `MarkoWizard`
@@ -23,6 +27,13 @@ The workflow publishes with [trusted publishing](https://docs.pypi.org/trusted-p
 Create an environment named `pypi` (Settings → Environments). Optionally add
 protection rules (required reviewers, tag restriction `v*`).
 
+### GHCR package visibility
+
+The first `docker-publish` run creates a **private** package even though the repo
+is public. After it, go to the org's *Packages* → `markowizard` → *Package
+settings* → set visibility to **Public** so `docker pull` works without auth.
+One-time.
+
 ## Cutting a release
 
 1. Bump `version` in `pyproject.toml` (and update `CHANGELOG.md` if present).
@@ -32,11 +43,10 @@ protection rules (required reviewers, tag restriction `v*`).
    git tag v0.1.0
    git push origin v0.1.0
    ```
-4. Watch the **Publish** workflow. On success:
+4. Watch both workflows. On success:
    - `markowizard` <version> is on PyPI
-   - `ghcr.io/outliersanalytics/markowizard:<version>` and `:<major>.<minor>` are pushed
+   - `ghcr.io/outliersanalytics/markowizard:<version>`, `:<major>.<minor>`, and
+     `:latest` are pushed (`:latest` only for non-prerelease tags)
 
-Use `v0.1.0rc1`-style tags for pre-releases (PyPI treats them as pre-releases).
-
-> The container's `:latest` tag and its dependency setup still need work — see
-> the open packaging follow-ups. This doc covers the PyPI release path.
+Use `v0.1.0rc1`-style tags for pre-releases — PyPI marks them as pre-releases and
+the image `:latest` tag is skipped.

--- a/backend/router.py
+++ b/backend/router.py
@@ -22,6 +22,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+@router.get("/health")
+async def health() -> dict[str, str]:
+    """Liveness probe."""
+    return {"status": "ok"}
+
+
 @router.post("/analyze", response_model=AnalyzeResponse)
 async def analyze(request: AnalyzeRequest) -> AnalyzeResponse:
     """


### PR DESCRIPTION
Makes the container release path actually work, and separates it from the PyPI one.

## Dockerfile

Two bugs that would have shipped a broken `v0.1.0` image:

1. **Editable install.** `uv sync` installed `markowizard` as an editable `.pth` → the runtime stage (which never copied `markowizard/`) crashed on startup with `ModuleNotFoundError`. Now `uv sync --frozen --no-dev --no-editable` puts it in `site-packages`.
2. **No web server.** Since the `web` extra was removed, nothing installed fastapi/uvicorn. Now `uv pip install -r backend/requirements.txt`.

Also: pinned `UV_VERSION`, `--frozen`, BuildKit cache mounts, non-root `app` user, `HEALTHCHECK`.

## `GET /api/health`

New endpoint returning `{"status": "ok"}` — used by the Docker healthcheck.

## Workflow split

- `python-publish.yml` → **PyPI only** (matches the name and the trusted-publisher registration).
- `docker-publish.yml` → **GHCR only** (new).
- Both trigger on `v*` tags and reuse `ci.yml` as a gate.
- `flavor: latest=auto` replaces the `enable={{is_default_branch}}` gate, which never fired on tag pushes — so `:latest` will now actually be published (README promises it).

`RELEASING.md` updated (both workflows; GHCR "make package public" one-time step).

## Verified locally

```
docker build → ok
GET /api/health  → {"status":"ok"} [200]
GET /            → index.html [200]
POST /api/analyze → efficient frontier for AAPL/MSFT, yfinance fetch works [200]
container user   → uid 999 (app)
healthcheck      → healthy
```

## Follow-up (not here)

`backend/` still has no automated tests — the new `/api/health` and the analyze flow are only covered by the manual check above and the image build.