### PR TITLE
Add per-asset statistics and explicit min-variance portfolio to /api/analyze

### DIFF
--- a/backend/router.py
+++ b/backend/router.py
@@ -12,6 +12,7 @@ from markowizard.data import compute_monthly_returns, fetch_prices
 from .schemas import (
     AnalyzeRequest,
     AnalyzeResponse,
+    AssetStatistics,
     CapitalAllocationPoint,
     MaxSharpePortfolio,
     PortfolioMetrics,
@@ -67,6 +68,16 @@ async def analyze(request: AnalyzeRequest) -> AnalyzeResponse:
         corr_matrix = returns.corr()
         correlation_matrix: list[list[float]] = corr_matrix.values.tolist()
 
+        # 3b. Standalone per-asset statistics (independent of any portfolio weighting)
+        asset_statistics = [
+            AssetStatistics(
+                ticker=ticker,
+                expected_return=float(returns[ticker].mean()),
+                volatility=float(returns[ticker].std()),
+            )
+            for ticker in returns.columns
+        ]
+
         # 4. Optimize
         optimizer = MarkowitzOptimizer(returns)
         portfolios = optimizer.optimize()
@@ -99,7 +110,8 @@ async def analyze(request: AnalyzeRequest) -> AnalyzeResponse:
             for p in cal_points_raw
         ]
 
-        # 7. Build efficient frontier list
+        # 7. Build efficient frontier list. MarkowitzOptimizer.optimize() sorts by
+        # risk ascending, so frontier[0] below is the minimum-variance portfolio.
         frontier: list[PortfolioMetrics] = []
         for _, row in portfolios.iterrows():
             weights = {
@@ -118,8 +130,10 @@ async def analyze(request: AnalyzeRequest) -> AnalyzeResponse:
             tickers=tickers,
             efficient_frontier=frontier,
             max_sharpe_portfolio=max_sharpe_portfolio,
+            min_variance_portfolio=frontier[0],
             capital_allocation_line=cal_points,
             correlation_matrix=correlation_matrix,
+            asset_statistics=asset_statistics,
         )
 
     except HTTPException:

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -42,11 +42,21 @@ class CapitalAllocationPoint(BaseModel):
     label: str
 
 
+class AssetStatistics(BaseModel):
+    """Standalone (non-portfolio) return/volatility statistics for one asset."""
+
+    ticker: str
+    expected_return: float
+    volatility: float
+
+
 class AnalyzeResponse(BaseModel):
     """Response from the /analyze endpoint."""
 
     tickers: list[str]
     efficient_frontier: list[PortfolioMetrics]
     max_sharpe_portfolio: MaxSharpePortfolio
+    min_variance_portfolio: PortfolioMetrics
     capital_allocation_line: list[CapitalAllocationPoint]
     correlation_matrix: list[list[float]]
+    asset_statistics: list[AssetStatistics]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from backend.main import app
+from markowizard.data import compute_monthly_returns
 
 TICKERS = ["AAA", "BBB", "CCC"]
 
@@ -60,6 +61,22 @@ def test_analyze_happy_path(client: TestClient, fake_prices: pd.DataFrame) -> No
     assert body["max_sharpe_portfolio"]["sharpe"] is not None
     assert len(body["capital_allocation_line"]) == 21
     assert np.allclose(np.array(body["correlation_matrix"]).shape, (3, 3))
+
+    # Minimum-variance portfolio is the lowest-risk point on the frontier.
+    min_var = body["min_variance_portfolio"]
+    assert set(min_var["weights"]) == set(TICKERS)
+    assert min_var["risk"] == min(p["risk"] for p in body["efficient_frontier"])
+    assert min_var == body["efficient_frontier"][0]
+
+    # Per-asset standalone statistics, independent of any portfolio weighting,
+    # should match mean/std of the same monthly returns the optimizer used.
+    monthly_returns = compute_monthly_returns(fake_prices)
+    stats_by_ticker = {s["ticker"]: s for s in body["asset_statistics"]}
+    assert set(stats_by_ticker) == set(TICKERS)
+    for ticker in TICKERS:
+        stats = stats_by_ticker[ticker]
+        assert stats["expected_return"] == pytest.approx(monthly_returns[ticker].mean())
+        assert stats["volatility"] == pytest.approx(monthly_returns[ticker].std())
 
 
 def test_analyze_reports_missing_tickers(client: TestClient, fake_prices: pd.DataFrame) -> None:


### PR DESCRIPTION
## Context

PR 1 of the planned widescreen "analytical workstation" report redesign (design handoff, not yet in-repo). The new report needs three things the current `/api/analyze` response doesn't carry:

1. **Per-asset expected return and volatility** — for the per-asset statistics table.
2. **The minimum-variance portfolio**, explicit rather than implicit.
3. Effective number of assets (`1 / Σwᵢ²`) — trivial client-side math, not added here.

This PR adds the first two, purely additively.

## Changes

- `backend/schemas.py`: new `AssetStatistics{ticker, expected_return, volatility}`; `AnalyzeResponse` gains `asset_statistics: list[AssetStatistics]` and `min_variance_portfolio: PortfolioMetrics`.
- `backend/router.py`: computes per-asset stats from the same monthly-returns DataFrame the optimizer already builds; `min_variance_portfolio` is `efficient_frontier[0]`, since `MarkowitzOptimizer.optimize()` already sorts the frontier ascending by risk — this just names that fact instead of leaving callers to assume it.
- `tests/test_api.py`: asserts `min_variance_portfolio` is the lowest-risk frontier point, and that per-asset stats match `mean`/`std` of the same monthly returns used by the optimizer.

No existing field changes; no request-shape changes. Fully backward compatible with the current frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)