### PR TITLE
Wire up the control rail and KPI band against the real API

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,279 @@
+/**
+ * MarkoWizard — analytical workstation.
+ *
+ * Owns the control-rail state (universe, history window, risk-free rate) and
+ * the KPI band. The rest of the report (frontier, allocation, correlation,
+ * per-asset statistics, saved runs) lands in later PRs and will read from
+ * the same `state` object this file sets up.
+ *
+ * No framework, no build step — plain DOM, matching the rest of the repo.
+ */
+
+const UNIVERSE = [
+  { t: "AAPL", n: "Apple" },
+  { t: "MSFT", n: "Microsoft" },
+  { t: "GOOGL", n: "Alphabet" },
+  { t: "AMZN", n: "Amazon" },
+  { t: "NVDA", n: "NVIDIA" },
+  { t: "SPY", n: "S&P 500 ETF" },
+  { t: "QQQ", n: "Nasdaq 100 ETF" },
+  { t: "BND", n: "Total Bond ETF" },
+  { t: "GLD", n: "Gold ETF" },
+  { t: "VNQ", n: "Real Estate ETF" },
+];
+
+const DEFAULT_SEL = [0, 1, 5, 7, 8]; // AAPL, MSFT, SPY, BND, GLD
+
+const PERIOD_WORDS = {
+  "1y": "1-year",
+  "2y": "2-year",
+  "5y": "5-year",
+  "10y": "10-year",
+  max: "all available",
+};
+
+// Pending vs. applied mirrors the design handoff's state shape: `sel` /
+// `period` / `rfIdx` are what the rail currently shows; `appliedSel` / etc.
+// are what `result` was actually solved from. They start out equal (we
+// auto-run once on load), and diverge the moment the user touches a control
+// — that's what drives "Run analysis" vs. "Re-run analysis".
+const state = {
+  sel: [...DEFAULT_SEL],
+  period: "5y",
+  rfIdx: 8,
+  appliedSel: [...DEFAULT_SEL],
+  appliedPeriod: "5y",
+  appliedRfIdx: 8,
+  iF: null, // frontier selection; null = tangency (max Sharpe). Wired up in a later PR.
+  cash: 0, // cash blend; wired up in a later PR.
+  units: null, // null | 'annual'
+  running: false,
+  result: null,
+  error: null,
+  solvedAt: null,
+};
+
+function isAnnual() {
+  return state.units === "annual";
+}
+function toReturn(v) {
+  return isAnnual() ? Math.pow(1 + v, 12) - 1 : v;
+}
+function toVol(v) {
+  return isAnnual() ? v * Math.sqrt(12) : v;
+}
+function toSharpe(v) {
+  return isAnnual() ? v * Math.sqrt(12) : v;
+}
+function pct(v, decimals = 2) {
+  return (v * 100).toFixed(decimals) + "%";
+}
+function rfOf(idx) {
+  return +(idx * 0.00025).toFixed(5);
+}
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+  })[c]);
+}
+
+function isStale() {
+  return (
+    state.sel.join() !== state.appliedSel.join() ||
+    state.period !== state.appliedPeriod ||
+    state.rfIdx !== state.appliedRfIdx
+  );
+}
+
+/** The portfolio the KPI band (and, later, the rest of the report) reads
+ * from. `iF` isn't selectable yet (that's the frontier chart's job, PR 4),
+ * so this always resolves to the tangency portfolio for now. */
+function selectedPortfolio() {
+  if (!state.result) return null;
+  if (state.iF == null) return state.result.max_sharpe_portfolio;
+  return state.result.efficient_frontier[state.iF];
+}
+
+async function runAnalysis() {
+  if (state.running) return;
+  state.running = true;
+  state.error = null;
+  render();
+
+  const tickers = state.sel.map((i) => UNIVERSE[i].t);
+  try {
+    const resp = await fetch("/api/analyze", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tickers,
+        period: state.period,
+        risk_free_rate: rfOf(state.rfIdx),
+      }),
+    });
+    const body = await resp.json().catch(() => ({}));
+    if (!resp.ok) {
+      throw new Error(body.detail || `Request failed (${resp.status})`);
+    }
+
+    state.result = body;
+    state.appliedSel = [...state.sel];
+    state.appliedPeriod = state.period;
+    state.appliedRfIdx = state.rfIdx;
+    state.iF = null;
+    state.cash = 0;
+    state.solvedAt = new Date().toTimeString().slice(0, 5);
+  } catch (err) {
+    state.error = err.message || String(err);
+  } finally {
+    state.running = false;
+    render();
+  }
+}
+
+/* ── Rendering ───────────────────────────────────────────────────────── */
+
+function renderHeader() {
+  const universeTag = document.getElementById("mw-header-universe");
+  const periodTag = document.getElementById("mw-header-period");
+  const status = document.getElementById("mw-header-status");
+  const unitsBtn = document.getElementById("mw-units-btn");
+
+  const shownSel = state.result ? state.appliedSel : state.sel;
+  const shownPeriod = state.result ? state.appliedPeriod : state.period;
+  universeTag.textContent = shownSel.map((i) => UNIVERSE[i].t).join(" · ");
+  periodTag.textContent = (shownPeriod === "max" ? "Max" : shownPeriod.toUpperCase()) + " monthly";
+  status.textContent = state.result ? `Solved ${state.solvedAt}` : "Not run yet";
+  unitsBtn.textContent = isAnnual() ? "Annualized" : "Monthly";
+
+  const runBtn = document.getElementById("mw-run-btn");
+  runBtn.textContent = isStale() ? "Re-run analysis" : "Run analysis";
+  runBtn.disabled = state.running;
+}
+
+function renderChips() {
+  document.getElementById("mw-chips").querySelectorAll(".mw-chip").forEach((btn) => {
+    const idx = +btn.dataset.idx;
+    btn.classList.toggle("mw-chip--selected", state.sel.includes(idx));
+  });
+  document.getElementById("mw-chip-count").textContent =
+    `${state.sel.length} of ${UNIVERSE.length} selected · minimum 2`;
+}
+
+function renderOverlay() {
+  const overlay = document.getElementById("mw-overlay");
+  overlay.hidden = !state.running;
+  document.getElementById("mw-overlay-note").textContent =
+    state.sel.map((i) => UNIVERSE[i].t).join(" · ");
+}
+
+function kpiSectionHtml() {
+  const p = selectedPortfolio();
+  const unitWord = isAnnual() ? "annualized" : "monthly";
+  const n = state.appliedSel.length;
+
+  const headline = `The best risk-adjusted mix of your ${n} asset${n === 1 ? "" : "s"}`;
+  const periodWords = PERIOD_WORDS[state.appliedPeriod] || state.appliedPeriod;
+  const lede =
+    `Estimated from ${periodWords} monthly history at a ${pct(toReturn(rfOf(state.appliedRfIdx)))} ` +
+    `${unitWord} risk-free rate. Fully invested in the risky portfolio.`;
+
+  const weights = Object.values(p.weights);
+  const holdings = weights.filter((w) => w > 0.005).length;
+  const diversification = 1 / weights.reduce((a, w) => a + w * w, 0);
+
+  const kpis = [
+    { label: "Expected return", value: pct(toReturn(p.expected_return)), note: unitWord },
+    { label: "Volatility", value: pct(toVol(p.risk)), note: "standard deviation" },
+    { label: "Sharpe ratio", value: toSharpe(p.sharpe).toFixed(2), note: "unchanged by the cash blend", accent: true },
+    { label: "Holdings", value: String(holdings), note: `of ${n} assets, non-zero weight` },
+    { label: "Diversification", value: diversification.toFixed(1), note: "effective assets held" },
+  ];
+
+  return `
+    <section>
+      <h6 style="color:var(--color-accent-300);margin-bottom:var(--space-2)">Portfolio report</h6>
+      <h1 class="mw-headline">${escapeHtml(headline)}</h1>
+      <p class="text-muted mw-lede">${escapeHtml(lede)}</p>
+      <div class="mw-kpi-grid">
+        ${kpis.map((k) => `
+          <div class="card elev-sm" style="gap:var(--space-1)">
+            <span class="card-kicker">${escapeHtml(k.label)}</span>
+            <span class="mw-kpi-value${k.accent ? " mw-kpi-value--accent" : ""}">${escapeHtml(k.value)}</span>
+            <span class="text-muted" style="font-size:11.5px">${escapeHtml(k.note)}</span>
+          </div>`).join("")}
+      </div>
+    </section>`;
+}
+
+function errorCardHtml() {
+  return `
+    <div class="card elev-sm mw-error">
+      <span class="card-kicker">Analysis failed</span>
+      <p class="card-body">${escapeHtml(state.error)}</p>
+      <button type="button" class="btn btn-secondary" data-action="run" style="align-self:flex-start">Retry</button>
+    </div>`;
+}
+
+function renderKpiSlot() {
+  const slot = document.getElementById("mw-kpi-slot");
+  if (state.error) {
+    slot.innerHTML = errorCardHtml();
+  } else if (state.result) {
+    slot.innerHTML = kpiSectionHtml();
+  } else {
+    slot.innerHTML = "";
+  }
+}
+
+function render() {
+  renderHeader();
+  renderChips();
+  renderOverlay();
+  renderKpiSlot();
+}
+
+/* ── Event wiring ────────────────────────────────────────────────────── */
+
+function init() {
+  document.getElementById("mw-chips").addEventListener("click", (e) => {
+    const btn = e.target.closest(".mw-chip");
+    if (!btn) return;
+    const idx = +btn.dataset.idx;
+    const selected = state.sel.includes(idx);
+    if (selected && state.sel.length <= 2) return; // minimum 2, per the handoff
+    state.sel = selected ? state.sel.filter((i) => i !== idx) : [...state.sel, idx].sort((a, b) => a - b);
+    render();
+  });
+
+  document.getElementById("mw-period").querySelectorAll('input[name="mwperiod"]').forEach((input) => {
+    input.addEventListener("change", () => {
+      state.period = input.value;
+      render();
+    });
+  });
+
+  const rf = document.getElementById("mwrf");
+  rf.addEventListener("input", () => {
+    state.rfIdx = +rf.value;
+    document.getElementById("mwrf-display").textContent = pct(toReturn(rfOf(state.rfIdx)));
+    render();
+  });
+
+  document.getElementById("mw-units-btn").addEventListener("click", () => {
+    state.units = isAnnual() ? null : "annual";
+    render();
+  });
+
+  // Delegated: both the rail's Run button and the error card's Retry button
+  // carry data-action="run" — the latter only exists after a re-render, so
+  // it can't have a listener attached directly.
+  document.body.addEventListener("click", (e) => {
+    if (e.target.closest('[data-action="run"]')) runAnalysis();
+  });
+
+  render();
+  runAnalysis();
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,10 +18,10 @@
             <span class="mw-header__divider"></span>
             <img src="assets/markowizard-wordmark-light.svg" alt="MarkoWizard" />
         </a>
-        <span class="tag tag-neutral">AAPL · MSFT · SPY · BND · GLD</span>
-        <span class="tag tag-outline">5Y monthly</span>
-        <span class="text-muted" style="font-size: 12px">Not run yet</span>
-        <button type="button" class="btn btn-secondary" disabled>Monthly</button>
+        <span class="tag tag-neutral" id="mw-header-universe">AAPL · MSFT · SPY · BND · GLD</span>
+        <span class="tag tag-outline" id="mw-header-period">5Y monthly</span>
+        <span class="text-muted" style="font-size: 12px" id="mw-header-status">Not run yet</span>
+        <button type="button" class="btn btn-secondary" id="mw-units-btn">Monthly</button>
     </header>
 
     <div class="mw-shell">
@@ -29,24 +29,24 @@
 
             <div class="card elev-sm">
                 <h6 style="margin: 0; color: var(--color-accent-300)">Universe</h6>
-                <div style="display: flex; flex-wrap: wrap; gap: var(--space-2)">
-                    <button type="button" class="tag mw-chip mw-chip--selected" title="Apple">AAPL</button>
-                    <button type="button" class="tag mw-chip mw-chip--selected" title="Microsoft">MSFT</button>
-                    <button type="button" class="tag mw-chip" title="Alphabet">GOOGL</button>
-                    <button type="button" class="tag mw-chip" title="Amazon">AMZN</button>
-                    <button type="button" class="tag mw-chip" title="NVIDIA">NVDA</button>
-                    <button type="button" class="tag mw-chip mw-chip--selected" title="S&amp;P 500 ETF">SPY</button>
-                    <button type="button" class="tag mw-chip" title="Nasdaq 100 ETF">QQQ</button>
-                    <button type="button" class="tag mw-chip mw-chip--selected" title="Total Bond ETF">BND</button>
-                    <button type="button" class="tag mw-chip mw-chip--selected" title="Gold ETF">GLD</button>
-                    <button type="button" class="tag mw-chip" title="Real Estate ETF">VNQ</button>
+                <div class="mw-chip-row" id="mw-chips">
+                    <button type="button" class="tag mw-chip mw-chip--selected" data-idx="0" title="Apple">AAPL</button>
+                    <button type="button" class="tag mw-chip mw-chip--selected" data-idx="1" title="Microsoft">MSFT</button>
+                    <button type="button" class="tag mw-chip" data-idx="2" title="Alphabet">GOOGL</button>
+                    <button type="button" class="tag mw-chip" data-idx="3" title="Amazon">AMZN</button>
+                    <button type="button" class="tag mw-chip" data-idx="4" title="NVIDIA">NVDA</button>
+                    <button type="button" class="tag mw-chip mw-chip--selected" data-idx="5" title="S&amp;P 500 ETF">SPY</button>
+                    <button type="button" class="tag mw-chip" data-idx="6" title="Nasdaq 100 ETF">QQQ</button>
+                    <button type="button" class="tag mw-chip mw-chip--selected" data-idx="7" title="Total Bond ETF">BND</button>
+                    <button type="button" class="tag mw-chip mw-chip--selected" data-idx="8" title="Gold ETF">GLD</button>
+                    <button type="button" class="tag mw-chip" data-idx="9" title="Real Estate ETF">VNQ</button>
                 </div>
-                <div class="text-muted" style="font-size: 11px">5 of 10 selected · minimum 2</div>
+                <div class="text-muted" style="font-size: 11px" id="mw-chip-count">5 of 10 selected · minimum 2</div>
             </div>
 
             <div class="card elev-sm">
                 <h6 style="margin: 0; color: var(--color-accent-300)">History window</h6>
-                <div class="seg" style="width: 100%">
+                <div class="seg" style="width: 100%" id="mw-period">
                     <label class="seg-opt" style="flex: 1"><input type="radio" name="mwperiod" value="1y">1Y</label>
                     <label class="seg-opt" style="flex: 1"><input type="radio" name="mwperiod" value="2y">2Y</label>
                     <label class="seg-opt" style="flex: 1"><input type="radio" name="mwperiod" value="5y" checked>5Y</label>
@@ -58,12 +58,12 @@
                     <div style="display: flex; gap: var(--space-2); align-items: center">
                         <input id="mwrf" type="range" min="0" max="80" step="5" value="8"
                             style="flex: 1; min-width: 0; accent-color: var(--color-accent); height: 20px" />
-                        <span style="font-family: var(--font-heading); font-size: 14px; min-width: 58px; text-align: right">0.20%</span>
+                        <span style="font-family: var(--font-heading); font-size: 14px; min-width: 58px; text-align: right" id="mwrf-display">0.20%</span>
                     </div>
                 </div>
             </div>
 
-            <button type="button" class="btn btn-primary btn-block" disabled style="height: 38px">Run analysis</button>
+            <button type="button" class="btn btn-primary btn-block" id="mw-run-btn" data-action="run" style="height: 38px">Run analysis</button>
 
             <nav class="mw-toc" aria-label="Report sections">
                 <a href="#frontier">01 Efficient frontier</a>
@@ -82,15 +82,28 @@
         </aside>
 
         <main id="top" class="mw-report">
+            <div id="mw-kpi-slot"></div>
             <div class="card elev-sm mw-placeholder">
                 <span class="card-kicker">Coming soon</span>
                 <p class="card-body">
-                    The report (efficient frontier, allocation, correlation matrix, per-asset statistics and saved
-                    runs) is being rebuilt section by section — see the implementation plan for the staged PRs ahead.
+                    The rest of the report (efficient frontier, allocation, correlation matrix, per-asset statistics
+                    and saved runs) is being rebuilt section by section — see the implementation plan for the staged
+                    PRs ahead.
                 </p>
             </div>
         </main>
     </div>
+
+    <div id="mw-overlay" class="mw-overlay" hidden>
+        <div class="card elev-lg mw-overlay__card">
+            <img src="assets/images/mascote-analise-de-dados.png" alt="" />
+            <div class="mw-spinner"></div>
+            <div class="mw-overlay__title">Solving 60 quadratic programs</div>
+            <div class="text-muted mw-overlay__note" id="mw-overlay-note"></div>
+        </div>
+    </div>
+
+    <script src="app.js"></script>
 </body>
 
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -79,6 +79,14 @@
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 14px;
+
+  /* Semantic (outliers-design-system tokens/colors.json) — only --color-error
+     is used so far (analysis-failed states); the rest are here so later PRs
+     don't have to re-derive them. */
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-error: #ef4444;
+  --color-info: #3b82f6;
 }
 
 /* ── Reset & typography ─────────────────────────────────────────────── */
@@ -515,4 +523,92 @@ input[type="range"]:hover::-moz-range-thumb {
   text-align: center;
   gap: var(--space-2);
   padding: var(--space-8);
+}
+
+.mw-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+/* ── KPI band ────────────────────────────────────────────────────────── */
+
+.mw-headline {
+  font-size: clamp(30px, 3.4vw, 40px);
+  margin: 0 0 var(--space-3);
+}
+.mw-lede {
+  max-width: 64ch;
+  font-size: 15px;
+  margin-bottom: var(--space-8);
+}
+.mw-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(168px, 1fr));
+  gap: var(--space-4);
+}
+.mw-kpi-value {
+  font-family: var(--font-heading);
+  font-weight: 500;
+  font-size: clamp(24px, 2.2vw, 31px);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+}
+.mw-kpi-value--accent {
+  color: var(--color-accent-300);
+}
+
+/* ── Error state ─────────────────────────────────────────────────────── */
+
+.mw-error {
+  border: 1px solid color-mix(in srgb, var(--color-error) 35%, transparent);
+}
+.mw-error .card-kicker {
+  color: var(--color-error);
+}
+
+/* ── Running overlay ─────────────────────────────────────────────────── */
+
+.mw-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  background: color-mix(in srgb, var(--color-bg) 82%, transparent);
+}
+/* `.mw-overlay`'s own `display` would otherwise outrank the UA stylesheet's
+   `[hidden]{display:none}` at equal specificity (source order) — pin it
+   explicitly so setting the `hidden` property from JS always wins. */
+.mw-overlay[hidden] {
+  display: none;
+}
+.mw-overlay__card {
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-8);
+  width: min(300px, 86vw);
+}
+.mw-overlay__card img {
+  width: 84px;
+  height: 84px;
+  object-fit: contain;
+}
+.mw-overlay__title {
+  font-family: var(--font-heading);
+  font-size: 14px;
+  text-align: center;
+}
+.mw-overlay__note {
+  font-size: 11.5px;
+  text-align: center;
+}
+.mw-spinner {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 3px solid var(--color-neutral-800);
+  border-top-color: var(--color-accent-400);
+  animation: mwspin 0.8s linear infinite;
 }


### PR DESCRIPTION
## Context

PR 3 of the widescreen "analytical workstation" report redesign. Stacked on **#12** (targets that branch, not `main`, since it needs the shell/tokens/markup from it — merge #12 first, then this).

## What's here

- **`frontend/app.js`** (new) — a pending/applied state machine: `sel`/`period`/`rfIdx` are what the rail currently shows, `appliedSel`/`appliedPeriod`/`appliedRfIdx` are what the current result was actually solved from. They start equal — the app auto-runs once on load with the default universe, so there's always a report on screen instead of an empty first-load state (the handoff doesn't specify an initial-load state; this was my call, easy to change if you'd rather require an explicit first click). They diverge the moment a control changes, which is what flips the run button between "Run analysis" and "Re-run analysis".

  Wired up: universe chips (toggle, minimum-2 floor), history-window segment + risk-free slider, Run → `POST /api/analyze` with a running overlay, an error card with Retry for 400/500s (no design exists for error states — see the handoff's own Gaps list — so this reuses the card primitive + a semantic error color rather than inventing new visual language), the header's tags/status/units toggle, and the KPI band (live headline/lede + 5 KPI cards, monthly/annual conversion threaded through).

  The frontier selection and cash blend aren't wired yet — both default to "unset" (tangency, 0% cash), so the KPI band always reads `max_sharpe_portfolio` for now. Both land with their own sections in upcoming PRs, reading from this same state shape.

- **Real bug found and fixed along the way**: `.mw-overlay`'s own `display: grid` outranked the browser's `[hidden]{display:none}` at equal specificity (source order), so a "hidden" overlay still intercepted clicks underneath it. Caught by a headless-browser click test, fixed with an explicit `.mw-overlay[hidden]{display:none}`.

## Verification

Headless Chromium against a mocked `/api/analyze` (same approach as `tests/test_api.py`'s `fetch_prices` mock): confirmed the happy-path KPI values, monthly↔annual conversion, the chip minimum-2 floor (including the no-op case), and the error/retry path, plus visual screenshots of each state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)