### PR TITLE
Efficient frontier: SVG chart with drag selection, per-asset dots

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,10 +1,10 @@
 /**
  * MarkoWizard — analytical workstation.
  *
- * Owns the control-rail state (universe, history window, risk-free rate) and
- * the KPI band. The rest of the report (frontier, allocation, correlation,
- * per-asset statistics, saved runs) lands in later PRs and will read from
- * the same `state` object this file sets up.
+ * Owns the control-rail state (universe, history window, risk-free rate),
+ * the KPI band, and the efficient-frontier chart. The rest of the report
+ * (allocation, correlation, per-asset statistics, saved runs) lands in
+ * later PRs and will read from the same `state` object this file sets up.
  *
  * No framework, no build step — plain DOM, matching the rest of the repo.
  */
@@ -23,6 +23,13 @@ const UNIVERSE = [
 ];
 
 const DEFAULT_SEL = [0, 1, 5, 7, 8]; // AAPL, MSFT, SPY, BND, GLD
+
+// Chart series order, assigned by position in the selection — shared by the
+// frontier's per-asset dots and (in later PRs) the allocation donut/table.
+const CHART_PALETTE = [
+  "#2fc7cc", "#001d63", "#008ea0", "#42d4d7", "#64748b",
+  "#2c4d9c", "#00424c", "#94a3b8", "#5f7cbd", "#cbd5e1",
+];
 
 const PERIOD_WORDS = {
   "1y": "1-year",
@@ -44,8 +51,8 @@ const state = {
   appliedSel: [...DEFAULT_SEL],
   appliedPeriod: "5y",
   appliedRfIdx: 8,
-  iF: null, // frontier selection; null = tangency (max Sharpe). Wired up in a later PR.
-  cash: 0, // cash blend; wired up in a later PR.
+  iF: null, // frontier selection; null = tangency (max Sharpe)
+  cash: 0, // cash blend; wired up in a later PR
   units: null, // null | 'annual'
   running: false,
   result: null,
@@ -76,6 +83,21 @@ function escapeHtml(s) {
     "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
   })[c]);
 }
+function setText(id, text) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = text;
+}
+/** "Nice" tick step for an axis running 0..max: the largest of 1/2/2.5/5 x
+ * 10^n that still gives at least 4 ticks. Same rule the design handoff's
+ * prototype uses, so frontier tick counts match the reference screenshots. */
+function niceTickValues(max) {
+  const raw = max / 4;
+  const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+  const step = [1, 2, 2.5, 5, 10].map((m) => m * mag).find((s) => s >= raw) || mag * 10;
+  const out = [];
+  for (let v = 0; v <= max + 1e-9; v += step) out.push(v);
+  return out;
+}
 
 function isStale() {
   return (
@@ -85,13 +107,35 @@ function isStale() {
   );
 }
 
+/** Resolves `state.iF` against the current result: the effective frontier
+ * index, the tangency (max-Sharpe) index, and the descriptive label the
+ * design handoff uses for both the frontier stats panel and the KPI
+ * headline. `efficient_frontier[best]` and `max_sharpe_portfolio` are the
+ * same row from the backend's optimizer output, just serialized twice —
+ * reading through the frontier array here keeps a single source of truth
+ * for "which point is selected". */
+function resolveSelection(result) {
+  const pts = result.efficient_frontier;
+  const best = pts.reduce(
+    (b, p, i) => ((p.sharpe ?? -Infinity) > (pts[b].sharpe ?? -Infinity) ? i : b),
+    0,
+  );
+  const iF = state.iF == null ? best : Math.max(0, Math.min(pts.length - 1, state.iF));
+  let label;
+  if (iF === best) label = "Tangency portfolio — maximum Sharpe";
+  else if (iF === 0) label = "Minimum-variance portfolio";
+  else if (iF < best) label = "Below tangency — risk-averse";
+  else if (iF > pts.length - 5) label = "Frontier edge — single-asset concentration";
+  else label = "Above tangency — return-seeking";
+  return { iF, best, label, isBest: iF === best };
+}
+
 /** The portfolio the KPI band (and, later, the rest of the report) reads
- * from. `iF` isn't selectable yet (that's the frontier chart's job, PR 4),
- * so this always resolves to the tangency portfolio for now. */
+ * from. */
 function selectedPortfolio() {
   if (!state.result) return null;
-  if (state.iF == null) return state.result.max_sharpe_portfolio;
-  return state.result.efficient_frontier[state.iF];
+  const { iF } = resolveSelection(state.result);
+  return state.result.efficient_frontier[iF];
 }
 
 async function runAnalysis() {
@@ -172,7 +216,8 @@ function kpiSectionHtml() {
   const unitWord = isAnnual() ? "annualized" : "monthly";
   const n = state.appliedSel.length;
 
-  const headline = `The best risk-adjusted mix of your ${n} asset${n === 1 ? "" : "s"}`;
+  const { label, isBest } = resolveSelection(state.result);
+  const headline = isBest ? `The best risk-adjusted mix of your ${n} asset${n === 1 ? "" : "s"}` : label;
   const periodWords = PERIOD_WORDS[state.appliedPeriod] || state.appliedPeriod;
   const lede =
     `Estimated from ${periodWords} monthly history at a ${pct(toReturn(rfOf(state.appliedRfIdx)))} ` +
@@ -215,6 +260,281 @@ function errorCardHtml() {
     </div>`;
 }
 
+/* ── Efficient frontier ──────────────────────────────────────────────── */
+
+// SVG plot box, per the handoff: viewBox 0 0 880 470, x from 62 to 862
+// (zero at 62), y from 404 (zero) up to 26.
+const FR_X0 = 62;
+const FR_X_SPAN = 800;
+const FR_Y0 = 404;
+const FR_Y_SPAN = 378;
+
+// Rebuilt only when `state.result` changes (a new run) — holds the scale
+// functions and point coordinates the base SVG and the selection overlay
+// both read. Recomputing this on every drag frame would be wasteful and,
+// worse, would mean tearing down the SVG element mid-drag and losing its
+// pointer capture (see renderFrontier below).
+let frontierGeo = null;
+let frontierBaseResult = null;
+let frontierBaseUnits = null;
+
+function computeFrontierGeometry(result) {
+  const pts = result.efficient_frontier;
+  const assetStats = result.asset_statistics || [];
+  const xMax = Math.max(...pts.map((q) => q.risk), ...assetStats.map((a) => a.volatility)) * 1.08;
+  const yMax =
+    Math.max(...pts.map((q) => q.expected_return), ...assetStats.map((a) => a.expected_return)) * 1.12;
+  const X = (v) => FR_X0 + (v / xMax) * FR_X_SPAN;
+  const Y = (v) => FR_Y0 - (v / yMax) * FR_Y_SPAN;
+  const geo = pts.map((q) => ({ cx: +X(q.risk).toFixed(1), cy: +Y(q.expected_return).toFixed(1) }));
+  return { pts, assetStats, xMax, yMax, X, Y, geo };
+}
+
+/** Maps a pointer event's x position to the nearest frontier point by risk,
+ * accounting for the plot box's left inset — not a naive fraction of the
+ * SVG element's width. */
+function pickFrontierPoint(evt, svgEl) {
+  const rect = svgEl.getBoundingClientRect();
+  const t = Math.max(
+    0,
+    Math.min(1, (evt.clientX - rect.left - (FR_X0 / 880) * rect.width) / ((FR_X_SPAN / 880) * rect.width)),
+  );
+  const target = t * frontierGeo.xMax;
+  let bestIdx = 0;
+  let bestDist = Infinity;
+  frontierGeo.pts.forEach((q, i) => {
+    const d = Math.abs(q.risk - target);
+    if (d < bestDist) {
+      bestDist = d;
+      bestIdx = i;
+    }
+  });
+  state.iF = bestIdx;
+  render();
+}
+
+function frontierSectionHtml(result) {
+  const geo = frontierGeo;
+  const rf = rfOf(state.appliedRfIdx);
+  const { best } = resolveSelection(result);
+
+  const gridPath = niceTickValues(geo.yMax).map((v) => `M${FR_X0} ${geo.Y(v).toFixed(1)}H862`).join(" ");
+  const xTickPath = niceTickValues(geo.xMax).map((v) => `M${geo.X(v).toFixed(1)} ${FR_Y0}v7`).join(" ");
+  const dotsPath = geo.geo
+    .map((g) => `M${(g.cx - 2.2).toFixed(1)} ${g.cy}a2.2 2.2 0 1 0 4.4 0a2.2 2.2 0 1 0 -4.4 0`)
+    .join(" ");
+  const line = geo.geo.map((g) => `${g.cx},${g.cy}`).join(" ");
+  const mvp = geo.geo[0];
+  const tan = geo.geo[best];
+
+  const tanPoint = geo.pts[best];
+  const slope = (tanPoint.expected_return - rf) / tanPoint.risk;
+  let calX = geo.xMax;
+  let calY = rf + slope * calX;
+  if (calY > geo.yMax) {
+    calY = geo.yMax;
+    calX = (geo.yMax - rf) / slope;
+  }
+  const cal = {
+    x1: geo.X(0).toFixed(1), y1: geo.Y(rf).toFixed(1),
+    x2: geo.X(calX).toFixed(1), y2: geo.Y(calY).toFixed(1),
+    pctX: (((geo.X(calX) - 6) / 880) * 100).toFixed(2),
+    pctY: (((geo.Y(calY) + 6) / 470) * 100).toFixed(2),
+  };
+
+  const unitWord = isAnnual() ? "annualized" : "monthly";
+  const yTicks = niceTickValues(geo.yMax).map((v) => ({
+    pctY: ((geo.Y(v) / 470) * 100).toFixed(2),
+    label: pct(toReturn(v), isAnnual() ? 0 : 1),
+  }));
+  const xTicks = niceTickValues(geo.xMax).map((v) => ({
+    pctX: ((geo.X(v) / 880) * 100).toFixed(2),
+    label: pct(toVol(v), isAnnual() ? 0 : 1),
+  }));
+
+  const statsByTicker = Object.fromEntries(geo.assetStats.map((a) => [a.ticker, a]));
+  const assetDots = result.tickers
+    .map((t, k) => {
+      const a = statsByTicker[t];
+      if (!a) return null; // shouldn't happen — every requested ticker gets stats back
+      return {
+        t,
+        color: CHART_PALETTE[k % CHART_PALETTE.length],
+        pctX: ((geo.X(a.volatility) / 880) * 100).toFixed(2),
+        pctY: ((geo.Y(a.expected_return) / 470) * 100).toFixed(2),
+      };
+    })
+    .filter(Boolean);
+
+  return `
+    <section id="frontier">
+      <h6 style="color:var(--color-accent-300)">01 · Risk–return</h6>
+      <h3 style="margin-bottom:var(--space-2)">Efficient frontier</h3>
+      <p class="text-muted mw-section-lede">Every point is a portfolio the optimizer can build from your
+        ${result.tickers.length} assets. Click or drag along the curve to move the selection — the whole
+        report above follows it.</p>
+
+      <div class="mw-frontier-row">
+        <div class="card elev-sm mw-frontier-chart-card">
+          <div class="mw-frontier-plot">
+            <svg id="mw-frontier-svg" class="mw-frontier-svg" viewBox="0 0 880 470">
+              <path d="${gridPath}" fill="none" stroke="var(--color-neutral-900)" stroke-width="1"></path>
+              <path d="${xTickPath}" fill="none" stroke="var(--color-neutral-600)" stroke-width="1"></path>
+              <line x1="${FR_X0}" y1="${FR_Y0}" x2="862" y2="${FR_Y0}" stroke="var(--color-neutral-500)" stroke-width="1"></line>
+              <line x1="${cal.x1}" y1="${cal.y1}" x2="${cal.x2}" y2="${cal.y2}" stroke="var(--color-accent-300)" stroke-width="1.4" stroke-dasharray="6 5"></line>
+              <polyline points="${line}" fill="none" stroke="var(--color-accent-400)" stroke-width="2.6" stroke-linejoin="round"></polyline>
+              <path d="${dotsPath}" fill="var(--color-accent-300)" opacity="0.55"></path>
+              <circle cx="${mvp.cx}" cy="${mvp.cy}" r="4.5" fill="var(--color-bg)" stroke="var(--color-neutral-400)" stroke-width="1.8"></circle>
+              <circle cx="${tan.cx}" cy="${tan.cy}" r="6" fill="var(--color-bg)" stroke="var(--color-accent-200)" stroke-width="2.2"></circle>
+              <line id="mw-fr-cross-h" x1="${FR_X0}" y1="0" x2="0" y2="0" stroke="var(--color-accent)" stroke-width="1" stroke-dasharray="3 4" opacity="0.55"></line>
+              <line id="mw-fr-cross-v" x1="0" y1="0" x2="0" y2="${FR_Y0}" stroke="var(--color-accent)" stroke-width="1" stroke-dasharray="3 4" opacity="0.55"></line>
+              <circle id="mw-fr-sel-halo" cx="0" cy="0" r="12" fill="var(--color-accent)" opacity="0.18"></circle>
+              <circle id="mw-fr-sel-dot" cx="0" cy="0" r="6" fill="var(--color-accent)" stroke="var(--color-bg)" stroke-width="2"></circle>
+            </svg>
+            <div class="mw-frontier-overlay">
+              ${yTicks.map((t) => `<span style="left:0;width:5.9%;text-align:right;top:${t.pctY}%;transform:translateY(-50%)">${t.label}</span>`).join("")}
+              ${xTicks.map((t) => `<span style="left:${t.pctX}%;top:88.5%;transform:translateX(-50%)">${t.label}</span>`).join("")}
+              ${assetDots.map((a) => `
+                <span style="left:${a.pctX}%;top:${a.pctY}%;transform:translate(9px,-50%);font-size:12.5px;color:var(--color-neutral-300)">${escapeHtml(a.t)}</span>
+                <span style="left:${a.pctX}%;top:${a.pctY}%;transform:translate(-50%,-50%);width:9px;height:9px;border-radius:50%;border:2px solid ${a.color};background:var(--color-bg)"></span>`).join("")}
+              <span style="left:52.5%;top:95.5%;transform:translateX(-50%);font-size:13px;color:var(--color-neutral-300)">Volatility σ →</span>
+              <span style="left:7.4%;top:4.5%;font-size:13px;color:var(--color-neutral-300)">↑ Expected return · ${unitWord}</span>
+              <span style="left:${cal.pctX}%;top:${cal.pctY}%;transform:translate(-100%,14px);font-size:12.5px;color:var(--color-accent-300)">Capital allocation line</span>
+            </div>
+          </div>
+          <div class="mw-frontier-legend">
+            <span class="text-muted mw-legend-item"><span style="width:16px;height:2px;background:var(--color-accent-400);display:block"></span>Frontier</span>
+            <span class="text-muted mw-legend-item"><span style="width:10px;height:10px;border-radius:50%;border:2px solid var(--color-accent-200);display:block"></span>Tangency</span>
+            <span class="text-muted mw-legend-item"><span style="width:9px;height:9px;border-radius:50%;border:1.6px solid var(--color-neutral-400);display:block"></span>Minimum variance</span>
+            <span class="text-muted mw-legend-item"><span style="width:9px;height:9px;border-radius:50%;border:1.8px solid var(--color-neutral-500);display:block"></span>Single asset</span>
+          </div>
+        </div>
+
+        <div class="card elev-sm mw-frontier-stats">
+          <div>
+            <span class="card-kicker">Selected portfolio</span>
+            <div class="mw-frontier-stats__title" id="mw-fr-title"></div>
+          </div>
+          <div class="mw-frontier-stats__rows">
+            <div class="mw-frontier-stats__row"><span class="text-muted" style="font-size:12px">Expected return</span><span class="mw-frontier-stats__row-value" id="mw-fr-row-return"></span></div>
+            <div class="mw-frontier-stats__row"><span class="text-muted" style="font-size:12px">Volatility</span><span class="mw-frontier-stats__row-value" id="mw-fr-row-risk"></span></div>
+            <div class="mw-frontier-stats__row"><span class="text-muted" style="font-size:12px">Sharpe ratio</span><span class="mw-frontier-stats__row-value" style="color:var(--color-accent-300)" id="mw-fr-row-sharpe"></span></div>
+            <div class="mw-frontier-stats__row"><span class="text-muted" style="font-size:12px">Largest position</span><span class="mw-frontier-stats__row-value" id="mw-fr-row-largest"></span></div>
+          </div>
+          <p class="card-body" id="mw-fr-tip"></p>
+          <div style="display:flex;gap:var(--space-2)">
+            <button type="button" class="btn btn-secondary" data-action="frontier-mvp" style="flex:1">Min variance</button>
+            <button type="button" class="btn btn-primary" data-action="frontier-tan" style="flex:1">Max Sharpe</button>
+          </div>
+        </div>
+      </div>
+    </section>`;
+}
+
+function attachFrontierEvents() {
+  const svg = document.getElementById("mw-frontier-svg");
+  if (!svg) return;
+  svg.addEventListener("pointerdown", (e) => {
+    try {
+      if (e.pointerId != null) svg.setPointerCapture(e.pointerId);
+    } catch {
+      // Synthetic events (and some test harnesses) may lack a real pointerId.
+    }
+    svg._mwDragging = true;
+    pickFrontierPoint(e, svg);
+  });
+  svg.addEventListener("pointermove", (e) => {
+    if (svg._mwDragging) pickFrontierPoint(e, svg);
+  });
+  svg.addEventListener("pointerup", () => {
+    svg._mwDragging = false;
+  });
+  svg.addEventListener("pointercancel", () => {
+    svg._mwDragging = false;
+  });
+}
+
+/** Updates only the selection-dependent bits (crosshair, marker, stats
+ * panel) without touching the SVG element itself — rebuilding it mid-drag
+ * would drop the pointer capture attachFrontierEvents just set up. */
+function updateFrontierSelection() {
+  if (!state.result || !frontierGeo) return;
+  const { iF, best, label, isBest } = resolveSelection(state.result);
+  const p = frontierGeo.pts[iF];
+  const g = frontierGeo.geo[iF];
+
+  const crossH = document.getElementById("mw-fr-cross-h");
+  const crossV = document.getElementById("mw-fr-cross-v");
+  const halo = document.getElementById("mw-fr-sel-halo");
+  const dot = document.getElementById("mw-fr-sel-dot");
+  if (crossH) {
+    crossH.setAttribute("x2", g.cx);
+    crossH.setAttribute("y1", g.cy);
+    crossH.setAttribute("y2", g.cy);
+  }
+  if (crossV) {
+    crossV.setAttribute("x1", g.cx);
+    crossV.setAttribute("x2", g.cx);
+    crossV.setAttribute("y1", g.cy);
+  }
+  if (halo) {
+    halo.setAttribute("cx", g.cx);
+    halo.setAttribute("cy", g.cy);
+  }
+  if (dot) {
+    dot.setAttribute("cx", g.cx);
+    dot.setAttribute("cy", g.cy);
+  }
+
+  setText("mw-fr-title", label);
+  setText("mw-fr-row-return", pct(toReturn(p.expected_return)));
+  setText("mw-fr-row-risk", pct(toVol(p.risk)));
+  setText("mw-fr-row-sharpe", toSharpe(p.sharpe).toFixed(3));
+
+  const [largestTicker, largestWeight] = Object.entries(p.weights).reduce(
+    (a, [t, w]) => (w > a[1] ? [t, w] : a),
+    ["—", -Infinity],
+  );
+  setText("mw-fr-row-largest", `${largestTicker} · ${(largestWeight * 100).toFixed(0)}%`);
+
+  setText(
+    "mw-fr-tip",
+    isBest
+      ? "This is where the capital allocation line touches the frontier: no other long-only mix of these assets pays more return per unit of risk."
+      : iF < best
+        ? "Safer than the tangency portfolio, but every unit of risk here buys less return. Blending the tangency mix with cash dominates this point."
+        : "Past tangency the curve flattens: additional return costs more volatility than it returns. Low-volatility assets have dropped out.",
+  );
+}
+
+function renderFrontier() {
+  const slot = document.getElementById("mw-frontier-slot");
+  // A failed re-run leaves the previous `state.result` in place (see
+  // runAnalysis) so a transient failure doesn't blow away a working report;
+  // but showing a stale chart under the error card would be confusing, so
+  // the error card (in the KPI slot) takes over the whole report area.
+  if (!state.result || state.error) {
+    slot.innerHTML = "";
+    frontierGeo = null;
+    frontierBaseResult = null;
+    frontierBaseUnits = null;
+    return;
+  }
+  // Units (monthly/annual) change the axis titles and tick labels, which are
+  // baked into the static HTML below — not just the selection-dependent
+  // bits updateFrontierSelection touches — so a units change needs a base
+  // rebuild too. That's safe here (unlike mid-drag) because toggling units
+  // is a discrete click, never a pointermove while the SVG holds capture.
+  if (state.result !== frontierBaseResult || state.units !== frontierBaseUnits) {
+    frontierGeo = computeFrontierGeometry(state.result);
+    slot.innerHTML = frontierSectionHtml(state.result);
+    attachFrontierEvents();
+    frontierBaseResult = state.result;
+    frontierBaseUnits = state.units;
+  }
+  updateFrontierSelection();
+}
+
 function renderKpiSlot() {
   const slot = document.getElementById("mw-kpi-slot");
   if (state.error) {
@@ -231,6 +551,7 @@ function render() {
   renderChips();
   renderOverlay();
   renderKpiSlot();
+  renderFrontier();
 }
 
 /* ── Event wiring ────────────────────────────────────────────────────── */
@@ -265,11 +586,19 @@ function init() {
     render();
   });
 
-  // Delegated: both the rail's Run button and the error card's Retry button
-  // carry data-action="run" — the latter only exists after a re-render, so
-  // it can't have a listener attached directly.
+  // Delegated: the rail's Run button, the error card's Retry button, and the
+  // frontier stats panel's jump buttons are all rebuilt on every re-render,
+  // so none of them can have a listener attached directly.
   document.body.addEventListener("click", (e) => {
     if (e.target.closest('[data-action="run"]')) runAnalysis();
+    if (e.target.closest('[data-action="frontier-mvp"]')) {
+      state.iF = 0;
+      render();
+    }
+    if (e.target.closest('[data-action="frontier-tan"]')) {
+      state.iF = null;
+      render();
+    }
   });
 
   render();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -83,12 +83,12 @@
 
         <main id="top" class="mw-report">
             <div id="mw-kpi-slot"></div>
+            <div id="mw-frontier-slot"></div>
             <div class="card elev-sm mw-placeholder">
                 <span class="card-kicker">Coming soon</span>
                 <p class="card-body">
-                    The rest of the report (efficient frontier, allocation, correlation matrix, per-asset statistics
-                    and saved runs) is being rebuilt section by section — see the implementation plan for the staged
-                    PRs ahead.
+                    The rest of the report (allocation, correlation matrix, per-asset statistics and saved runs) is
+                    being rebuilt section by section — see the implementation plan for the staged PRs ahead.
                 </p>
             </div>
         </main>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -612,3 +612,90 @@ input[type="range"]:hover::-moz-range-thumb {
   border-top-color: var(--color-accent-400);
   animation: mwspin 0.8s linear infinite;
 }
+
+/* ── Section chrome shared by frontier/allocation/correlation/etc ──────── */
+
+.mw-section-lede {
+  max-width: 70ch;
+  font-size: 14px;
+  margin-bottom: var(--space-6);
+}
+
+/* ── Efficient frontier ──────────────────────────────────────────────── */
+
+.mw-frontier-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  align-items: stretch;
+}
+.mw-frontier-chart-card {
+  flex: 999 1 560px;
+  min-width: 0;
+  padding: var(--space-4);
+}
+.mw-frontier-plot {
+  position: relative;
+  width: 100%;
+}
+.mw-frontier-svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  touch-action: none;
+  cursor: crosshair;
+}
+.mw-frontier-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  font-size: 12.5px;
+  color: var(--color-neutral-400);
+  font-variant-numeric: tabular-nums;
+}
+.mw-frontier-overlay span {
+  position: absolute;
+  white-space: nowrap;
+}
+.mw-frontier-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  padding-top: var(--space-2);
+}
+.mw-frontier-legend .mw-legend-item {
+  font-size: 11.5px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.mw-frontier-stats {
+  flex: 1 1 276px;
+  min-width: 0;
+  gap: var(--space-4);
+  padding: var(--space-4);
+}
+.mw-frontier-stats__title {
+  font-family: var(--font-heading);
+  font-size: 18px;
+  line-height: 1.25;
+  margin-top: var(--space-1);
+}
+.mw-frontier-stats__rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.mw-frontier-stats__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  background: linear-gradient(to right, var(--color-divider), var(--color-divider)) no-repeat bottom /
+    100% 1px;
+  padding-bottom: var(--space-2);
+}
+.mw-frontier-stats__row-value {
+  font-family: var(--font-heading);
+  font-size: 16px;
+}


### PR DESCRIPTION
## Context

PR 4 of the widescreen "analytical workstation" report redesign — the highest-risk piece of the plan. Stacked on **#13** (targets that branch, not `main`).

## What's here

An SVG chart in absolute risk/return space (both axes start at zero, not min-max normalized — so the curve's real shape and its position relative to the capital allocation line are honest), with:
- the frontier curve + per-point dots
- every individual selected asset plotted as its own point (you can see it sitting below the frontier — diversification made visible)
- the capital allocation line, minimum-variance and tangency markers
- a pointer-drag selection that tracks the cursor 1:1 (mouse and touch), backed by a stats panel that follows it (expected return/volatility/Sharpe/largest position, plus explanatory copy that changes with position relative to tangency)
- "Min variance" / "Max Sharpe" jump buttons

No client-side solver — everything comes from the real `/api/analyze` response, per the handoff ("do not port the prototype's solver").

**`resolveSelection()`** is shared between the frontier stats panel and the KPI band: the KPI headline no longer hardcodes "best mix" copy — it now shows the same position-relative label the frontier panel does once you've dragged off the tangency point.

**Base vs. selection rendering is split deliberately.** The SVG and its static layers (grid, ticks, curve, CAL, asset dots, markers) only get rebuilt when the result or the unit changes; dragging just updates the crosshair/marker attributes and stats-panel text directly. This matters because `pointerdown` captures the pointer on the SVG element itself — an `innerHTML` rebuild mid-drag would silently drop that capture and break the gesture.

## Two real bugs found by testing, not inspection

- **Units toggle didn't update the chart's axis titles/ticks** — only the stats panel — because those live in the "base" HTML, which was keyed only on the result reference, and toggling units doesn't change that reference. Fixed by keying the base rebuild on `(result, units)` together. Safe to do since a units toggle is a discrete click, never a pointermove mid-drag.
- Re-confirmed the pointer-capture risk mentioned above doesn't actually occur: dragged to a non-default point, then toggled units, and checked the selection (and the marker's screen position) survived the base rebuild unchanged.

## Verification

Headless Chromium against a synthetic `/api/analyze` response shaped like a real efficient frontier (concave, tangency mid-curve, distinct from both endpoints): mouse-drag selection, the Min variance / Max Sharpe buttons, and the monthly/annual toggle, each checked against the rendered DOM plus screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)