### PR TITLE
Correlation matrix and per-asset statistics

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2,10 +2,10 @@
  * MarkoWizard — analytical workstation.
  *
  * Owns the control-rail state (universe, history window, risk-free rate),
- * the KPI band, the efficient-frontier chart, and the allocation donut/cash
- * blend/weights table. The rest of the report (correlation, per-asset
- * statistics, saved runs) lands in later PRs and will read from the same
- * `state` object this file sets up.
+ * the KPI band, the efficient-frontier chart, the allocation donut/cash
+ * blend/weights table, the correlation matrix, and per-asset statistics.
+ * Saved runs lands in a later PR and will read from the same `state`
+ * object this file sets up.
  *
  * No framework, no build step — plain DOM, matching the rest of the repo.
  */
@@ -720,6 +720,145 @@ function renderAllocation() {
   updateAllocation();
 }
 
+/* ── Correlation matrix ──────────────────────────────────────────────── */
+
+// Linear RGB interpolation from neutral-900 (0.0) to accent-600 (1.0). Text
+// stays ink-dark at every value — the ramp tops out light enough that a
+// contrast threshold (needed in the mobile design this superseded) isn't
+// needed here.
+const CORR_LOW_RGB = [241, 245, 249];
+const CORR_HIGH_RGB = [94, 213, 217];
+
+function correlationCellColor(v) {
+  const t = Math.max(0, Math.min(1, v));
+  const rgb = CORR_LOW_RGB.map((u, k) => Math.round(u + (CORR_HIGH_RGB[k] - u) * t));
+  return `rgb(${rgb.join(",")})`;
+}
+
+function correlationSectionHtml(result) {
+  const tickers = result.tickers;
+  const corr = result.correlation_matrix;
+
+  const heads = tickers
+    .map((t) => `<span style="text-align:center;font-size:11px;font-family:var(--font-heading);color:var(--color-neutral-400);padding-bottom:2px">${escapeHtml(t)}</span>`)
+    .join("");
+
+  const rows = tickers
+    .map((rowTicker, i) => {
+      const label = `<span style="display:flex;align-items:center;font-size:11.5px;font-family:var(--font-heading);color:var(--color-neutral-300)">${escapeHtml(rowTicker)}</span>`;
+      const cells = tickers
+        .map((_, j) => {
+          const v = corr[i][j];
+          return `<span style="aspect-ratio:1/1;border-radius:var(--radius-sm);display:flex;align-items:center;justify-content:center;font-size:11.5px;font-variant-numeric:tabular-nums;background:${correlationCellColor(v)};color:#0d1321">${v.toFixed(2)}</span>`;
+        })
+        .join("");
+      return label + cells;
+    })
+    .join("");
+
+  // Least/most correlated pair, scanning the upper triangle only (each pair once).
+  let lo = { v: 2, a: 0, b: 0 };
+  let hi = { v: -2, a: 0, b: 0 };
+  for (let i = 0; i < tickers.length; i++) {
+    for (let j = i + 1; j < tickers.length; j++) {
+      const v = corr[i][j];
+      if (v < lo.v) lo = { v, a: i, b: j };
+      if (v > hi.v) hi = { v, a: i, b: j };
+    }
+  }
+
+  const matrixMin = 58 + tickers.length * 41;
+  const periodWords = state.appliedPeriod === "max" ? "all available history" : state.appliedPeriod.replace("y", " years");
+
+  return `
+    <section id="correlation">
+      <h6 style="color:var(--color-accent-300)">03 · Diversification</h6>
+      <h3 style="margin-bottom:var(--space-2)">Correlation matrix</h3>
+      <p class="text-muted mw-section-lede">Pairwise correlation of monthly returns over ${escapeHtml(periodWords)}.
+        Low pairs are what let the optimizer cut risk without giving up return.</p>
+
+      <div class="mw-corr-row">
+        <div class="card elev-sm mw-corr-matrix-card">
+          <div class="mw-corr-grid" style="grid-template-columns:58px repeat(${tickers.length},minmax(38px,54px));min-width:${matrixMin}px">
+            <span></span>
+            ${heads}
+            ${rows}
+          </div>
+          <div class="mw-corr-legend">
+            <span class="text-muted" style="font-size:11px">0.0</span>
+            <span class="mw-corr-legend__bar"></span>
+            <span class="text-muted" style="font-size:11px">1.0</span>
+          </div>
+        </div>
+
+        <div class="card elev-sm mw-corr-callout">
+          <span class="card-kicker">Least correlated pair</span>
+          <div class="mw-corr-callout__pair">${escapeHtml(tickers[lo.a])} · ${escapeHtml(tickers[lo.b])}</div>
+          <div class="mw-corr-callout__value">${lo.v.toFixed(2)}</div>
+          <p class="card-body">Two assets that rarely move together reduce portfolio variance without reducing
+            expected return, which is why the optimizer holds both even when one has the weaker standalone record.</p>
+          <div class="mw-corr-callout__footer">
+            <span class="text-muted" style="font-size:12px">Most correlated</span>
+            <span style="font-family:var(--font-heading);font-size:13px">${escapeHtml(tickers[hi.a])} · ${escapeHtml(tickers[hi.b])} · ${hi.v.toFixed(2)}</span>
+          </div>
+        </div>
+      </div>
+    </section>`;
+}
+
+function renderCorrelation() {
+  const slot = document.getElementById("mw-correlation-slot");
+  slot.innerHTML = state.result && !state.error ? correlationSectionHtml(state.result) : "";
+}
+
+/* ── Per-asset statistics ────────────────────────────────────────────── */
+
+function assetStatsSectionHtml(result) {
+  const p = selectedPortfolio();
+  const rf = rfOf(state.appliedRfIdx);
+  const statsByTicker = Object.fromEntries((result.asset_statistics || []).map((a) => [a.ticker, a]));
+  const cols = "104px minmax(0,1fr) 124px 104px 136px 96px";
+
+  const rows = result.tickers
+    .map((t, k) => {
+      const a = statsByTicker[t];
+      const w = p.weights[t] ?? 0;
+      const standaloneSharpe = (a.expected_return - rf) / a.volatility;
+      const wColor = w > 0.005 ? "var(--color-text)" : "var(--color-neutral-600)";
+      return `
+        <div class="mw-grid-row mw-grid-row--body" style="grid-template-columns:${cols}">
+          <span class="mw-swatch"><span class="mw-swatch__dot" style="background:${CHART_PALETTE[k % CHART_PALETTE.length]}"></span>${escapeHtml(t)}</span>
+          <span class="text-muted" style="font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${escapeHtml(nameFor(t))}</span>
+          <span class="mw-num" style="text-align:right">${pct(toReturn(a.expected_return))}</span>
+          <span class="mw-num" style="text-align:right">${pct(toVol(a.volatility))}</span>
+          <span class="mw-num" style="text-align:right;color:var(--color-neutral-400)">${toSharpe(standaloneSharpe).toFixed(2)}</span>
+          <span class="mw-num" style="text-align:right;color:${wColor}">${pct(w, 1)}</span>
+        </div>`;
+    })
+    .join("");
+
+  return `
+    <section id="assets">
+      <h6 style="color:var(--color-accent-300)">04 · Inputs</h6>
+      <h3 style="margin-bottom:var(--space-2)">Per-asset statistics</h3>
+      <p class="text-muted mw-section-lede">What the optimizer was given. A high standalone Sharpe does not guarantee
+        a large weight — covariance decides.</p>
+      <div class="card elev-sm mw-table">
+        <div class="mw-table__inner" style="min-width:620px">
+          <div class="mw-grid-row mw-grid-row--head" style="grid-template-columns:${cols}">
+            <span>Asset</span><span>Name</span><span style="text-align:right">Expected return</span><span style="text-align:right">Volatility</span><span style="text-align:right">Sharpe, standalone</span><span style="text-align:right">Weight</span>
+          </div>
+          ${rows}
+        </div>
+      </div>
+    </section>`;
+}
+
+function renderAssetStats() {
+  const slot = document.getElementById("mw-assets-slot");
+  slot.innerHTML = state.result && !state.error ? assetStatsSectionHtml(state.result) : "";
+}
+
 function renderKpiSlot() {
   const slot = document.getElementById("mw-kpi-slot");
   if (state.error) {
@@ -738,6 +877,8 @@ function render() {
   renderKpiSlot();
   renderFrontier();
   renderAllocation();
+  renderCorrelation();
+  renderAssetStats();
 }
 
 /* ── Event wiring ────────────────────────────────────────────────────── */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -85,11 +85,12 @@
             <div id="mw-kpi-slot"></div>
             <div id="mw-frontier-slot"></div>
             <div id="mw-allocation-slot"></div>
+            <div id="mw-correlation-slot"></div>
+            <div id="mw-assets-slot"></div>
             <div class="card elev-sm mw-placeholder">
                 <span class="card-kicker">Coming soon</span>
                 <p class="card-body">
-                    The rest of the report (correlation matrix, per-asset statistics and saved runs) is being
-                    rebuilt section by section — see the implementation plan for the staged PRs ahead.
+                    Saved runs is being rebuilt next — see the implementation plan for the staged PRs ahead.
                 </p>
             </div>
         </main>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -846,3 +846,62 @@ input[type="range"]:hover::-moz-range-thumb {
 .mw-cash-card input[type="range"] {
   width: 100%;
 }
+
+/* ── Correlation matrix ──────────────────────────────────────────────── */
+
+.mw-corr-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  align-items: flex-start;
+}
+.mw-corr-matrix-card {
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: var(--space-6);
+  overflow-x: auto;
+}
+.mw-corr-grid {
+  display: grid;
+  justify-content: start;
+  gap: 3px;
+}
+.mw-corr-legend {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+  max-width: 320px;
+}
+.mw-corr-legend__bar {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, var(--color-neutral-900), var(--color-accent-600));
+  display: block;
+}
+.mw-corr-callout {
+  flex: 1 1 300px;
+  max-width: 400px;
+  min-width: 0;
+  padding: var(--space-6);
+  gap: var(--space-3);
+}
+.mw-corr-callout__pair {
+  font-family: var(--font-heading);
+  font-size: 20px;
+  line-height: 1.2;
+}
+.mw-corr-callout__value {
+  font-family: var(--font-heading);
+  font-size: 31px;
+  color: var(--color-accent-300);
+  letter-spacing: -0.02em;
+}
+.mw-corr-callout__footer {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-top: var(--space-2);
+  background: linear-gradient(to right, var(--color-divider), var(--color-divider)) no-repeat top / 100% 1px;
+}


### PR DESCRIPTION
## Context

PR 6 of the widescreen "analytical workstation" report redesign. Stacked on **#15** (targets that branch, not `main`).

## What's here

Both sections bundled in one PR since they share the grid-row table pattern #15 already built (`.mw-table`/`.mw-grid-row`/`.mw-num`), and neither has any interactive state of its own — no drag, no slider — so both are plain full-rebuild-on-render sections, unlike the frontier chart or allocation's cash slider.

- **Correlation matrix** — a CSS-grid matrix (not a `<table>`, matching the rest of the report), cell color linearly interpolated in RGB from neutral-900 to accent-600. Text stays ink-dark at every value — this ramp, unlike the earlier mobile design's, never needs a light/dark contrast threshold, since it tops out light enough that dark text stays correct throughout. The least/most-correlated-pair callout scans only the upper triangle so each pair is considered once.
- **Per-asset statistics** — standalone per-asset expected return/volatility (from `asset_statistics` — independent of any portfolio weighting), a client-computed standalone Sharpe, and a Weight column that reads through `selectedPortfolio()` — so, matching the handoff, it updates live as the frontier selection is dragged, not just at the tangency default. Zero/near-zero weights dim to neutral-600 rather than being hidden, so an asset the optimizer declined stays visible.

## Verification

Headless Chromium against a synthetic `/api/analyze` response: the matrix diagonal is 1.00 everywhere, the least/most correlated pairs match a manual scan of the input matrix, and the per-asset Weight column changes when jumping to the minimum-variance point on the frontier (confirming it tracks selection, not a fixed snapshot) — plus a full-page screenshot checked against the handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)