### PR TITLE
Close out the widescreen report redesign: merge the full frontend stack

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,279 @@
+/**
+ * MarkoWizard — analytical workstation.
+ *
+ * Owns the control-rail state (universe, history window, risk-free rate) and
+ * the KPI band. The rest of the report (frontier, allocation, correlation,
+ * per-asset statistics, saved runs) lands in later PRs and will read from
+ * the same `state` object this file sets up.
+ *
+ * No framework, no build step — plain DOM, matching the rest of the repo.
+ */
+
+const UNIVERSE = [
+  { t: "AAPL", n: "Apple" },
+  { t: "MSFT", n: "Microsoft" },
+  { t: "GOOGL", n: "Alphabet" },
+  { t: "AMZN", n: "Amazon" },
+  { t: "NVDA", n: "NVIDIA" },
+  { t: "SPY", n: "S&P 500 ETF" },
+  { t: "QQQ", n: "Nasdaq 100 ETF" },
+  { t: "BND", n: "Total Bond ETF" },
+  { t: "GLD", n: "Gold ETF" },
+  { t: "VNQ", n: "Real Estate ETF" },
+];
+
+const DEFAULT_SEL = [0, 1, 5, 7, 8]; // AAPL, MSFT, SPY, BND, GLD
+
+const PERIOD_WORDS = {
+  "1y": "1-year",
+  "2y": "2-year",
+  "5y": "5-year",
+  "10y": "10-year",
+  max: "all available",
+};
+
+// Pending vs. applied mirrors the design handoff's state shape: `sel` /
+// `period` / `rfIdx` are what the rail currently shows; `appliedSel` / etc.
+// are what `result` was actually solved from. They start out equal (we
+// auto-run once on load), and diverge the moment the user touches a control
+// — that's what drives "Run analysis" vs. "Re-run analysis".
+const state = {
+  sel: [...DEFAULT_SEL],
+  period: "5y",
+  rfIdx: 8,
+  appliedSel: [...DEFAULT_SEL],
+  appliedPeriod: "5y",
+  appliedRfIdx: 8,
+  iF: null, // frontier selection; null = tangency (max Sharpe). Wired up in a later PR.
+  cash: 0, // cash blend; wired up in a later PR.
+  units: null, // null | 'annual'
+  running: false,
+  result: null,
+  error: null,
+  solvedAt: null,
+};
+
+function isAnnual() {
+  return state.units === "annual";
+}
+function toReturn(v) {
+  return isAnnual() ? Math.pow(1 + v, 12) - 1 : v;
+}
+function toVol(v) {
+  return isAnnual() ? v * Math.sqrt(12) : v;
+}
+function toSharpe(v) {
+  return isAnnual() ? v * Math.sqrt(12) : v;
+}
+function pct(v, decimals = 2) {
+  return (v * 100).toFixed(decimals) + "%";
+}
+function rfOf(idx) {
+  return +(idx * 0.00025).toFixed(5);
+}
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+  })[c]);
+}
+
+function isStale() {
+  return (
+    state.sel.join() !== state.appliedSel.join() ||
+    state.period !== state.appliedPeriod ||
+    state.rfIdx !== state.appliedRfIdx
+  );
+}
+
+/** The portfolio the KPI band (and, later, the rest of the report) reads
+ * from. `iF` isn't selectable yet (that's the frontier chart's job, PR 4),
+ * so this always resolves to the tangency portfolio for now. */
+function selectedPortfolio() {
+  if (!state.result) return null;
+  if (state.iF == null) return state.result.max_sharpe_portfolio;
+  return state.result.efficient_frontier[state.iF];
+}
+
+async function runAnalysis() {
+  if (state.running) return;
+  state.running = true;
+  state.error = null;
+  render();
+
+  const tickers = state.sel.map((i) => UNIVERSE[i].t);
+  try {
+    const resp = await fetch("/api/analyze", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tickers,
+        period: state.period,
+        risk_free_rate: rfOf(state.rfIdx),
+      }),
+    });
+    const body = await resp.json().catch(() => ({}));
+    if (!resp.ok) {
+      throw new Error(body.detail || `Request failed (${resp.status})`);
+    }
+
+    state.result = body;
+    state.appliedSel = [...state.sel];
+    state.appliedPeriod = state.period;
+    state.appliedRfIdx = state.rfIdx;
+    state.iF = null;
+    state.cash = 0;
+    state.solvedAt = new Date().toTimeString().slice(0, 5);
+  } catch (err) {
+    state.error = err.message || String(err);
+  } finally {
+    state.running = false;
+    render();
+  }
+}
+
+/* ── Rendering ───────────────────────────────────────────────────────── */
+
+function renderHeader() {
+  const universeTag = document.getElementById("mw-header-universe");
+  const periodTag = document.getElementById("mw-header-period");
+  const status = document.getElementById("mw-header-status");
+  const unitsBtn = document.getElementById("mw-units-btn");
+
+  const shownSel = state.result ? state.appliedSel : state.sel;
+  const shownPeriod = state.result ? state.appliedPeriod : state.period;
+  universeTag.textContent = shownSel.map((i) => UNIVERSE[i].t).join(" · ");
+  periodTag.textContent = (shownPeriod === "max" ? "Max" : shownPeriod.toUpperCase()) + " monthly";
+  status.textContent = state.result ? `Solved ${state.solvedAt}` : "Not run yet";
+  unitsBtn.textContent = isAnnual() ? "Annualized" : "Monthly";
+
+  const runBtn = document.getElementById("mw-run-btn");
+  runBtn.textContent = isStale() ? "Re-run analysis" : "Run analysis";
+  runBtn.disabled = state.running;
+}
+
+function renderChips() {
+  document.getElementById("mw-chips").querySelectorAll(".mw-chip").forEach((btn) => {
+    const idx = +btn.dataset.idx;
+    btn.classList.toggle("mw-chip--selected", state.sel.includes(idx));
+  });
+  document.getElementById("mw-chip-count").textContent =
+    `${state.sel.length} of ${UNIVERSE.length} selected · minimum 2`;
+}
+
+function renderOverlay() {
+  const overlay = document.getElementById("mw-overlay");
+  overlay.hidden = !state.running;
+  document.getElementById("mw-overlay-note").textContent =
+    state.sel.map((i) => UNIVERSE[i].t).join(" · ");
+}
+
+function kpiSectionHtml() {
+  const p = selectedPortfolio();
+  const unitWord = isAnnual() ? "annualized" : "monthly";
+  const n = state.appliedSel.length;
+
+  const headline = `The best risk-adjusted mix of your ${n} asset${n === 1 ? "" : "s"}`;
+  const periodWords = PERIOD_WORDS[state.appliedPeriod] || state.appliedPeriod;
+  const lede =
+    `Estimated from ${periodWords} monthly history at a ${pct(toReturn(rfOf(state.appliedRfIdx)))} ` +
+    `${unitWord} risk-free rate. Fully invested in the risky portfolio.`;
+
+  const weights = Object.values(p.weights);
+  const holdings = weights.filter((w) => w > 0.005).length;
+  const diversification = 1 / weights.reduce((a, w) => a + w * w, 0);
+
+  const kpis = [
+    { label: "Expected return", value: pct(toReturn(p.expected_return)), note: unitWord },
+    { label: "Volatility", value: pct(toVol(p.risk)), note: "standard deviation" },
+    { label: "Sharpe ratio", value: toSharpe(p.sharpe).toFixed(2), note: "unchanged by the cash blend", accent: true },
+    { label: "Holdings", value: String(holdings), note: `of ${n} assets, non-zero weight` },
+    { label: "Diversification", value: diversification.toFixed(1), note: "effective assets held" },
+  ];
+
+  return `
+    <section>
+      <h6 style="color:var(--color-accent-300);margin-bottom:var(--space-2)">Portfolio report</h6>
+      <h1 class="mw-headline">${escapeHtml(headline)}</h1>
+      <p class="text-muted mw-lede">${escapeHtml(lede)}</p>
+      <div class="mw-kpi-grid">
+        ${kpis.map((k) => `
+          <div class="card elev-sm" style="gap:var(--space-1)">
+            <span class="card-kicker">${escapeHtml(k.label)}</span>
+            <span class="mw-kpi-value${k.accent ? " mw-kpi-value--accent" : ""}">${escapeHtml(k.value)}</span>
+            <span class="text-muted" style="font-size:11.5px">${escapeHtml(k.note)}</span>
+          </div>`).join("")}
+      </div>
+    </section>`;
+}
+
+function errorCardHtml() {
+  return `
+    <div class="card elev-sm mw-error">
+      <span class="card-kicker">Analysis failed</span>
+      <p class="card-body">${escapeHtml(state.error)}</p>
+      <button type="button" class="btn btn-secondary" data-action="run" style="align-self:flex-start">Retry</button>
+    </div>`;
+}
+
+function renderKpiSlot() {
+  const slot = document.getElementById("mw-kpi-slot");
+  if (state.error) {
+    slot.innerHTML = errorCardHtml();
+  } else if (state.result) {
+    slot.innerHTML = kpiSectionHtml();
+  } else {
+    slot.innerHTML = "";
+  }
+}
+
+function render() {
+  renderHeader();
+  renderChips();
+  renderOverlay();
+  renderKpiSlot();
+}
+
+/* ── Event wiring ────────────────────────────────────────────────────── */
+
+function init() {
+  document.getElementById("mw-chips").addEventListener("click", (e) => {
+    const btn = e.target.closest(".mw-chip");
+    if (!btn) return;
+    const idx = +btn.dataset.idx;
+    const selected = state.sel.includes(idx);
+    if (selected && state.sel.length <= 2) return; // minimum 2, per the handoff
+    state.sel = selected ? state.sel.filter((i) => i !== idx) : [...state.sel, idx].sort((a, b) => a - b);
+    render();
+  });
+
+  document.getElementById("mw-period").querySelectorAll('input[name="mwperiod"]').forEach((input) => {
+    input.addEventListener("change", () => {
+      state.period = input.value;
+      render();
+    });
+  });
+
+  const rf = document.getElementById("mwrf");
+  rf.addEventListener("input", () => {
+    state.rfIdx = +rf.value;
+    document.getElementById("mwrf-display").textContent = pct(toReturn(rfOf(state.rfIdx)));
+    render();
+  });
+
+  document.getElementById("mw-units-btn").addEventListener("click", () => {
+    state.units = isAnnual() ? null : "annual";
+    render();
+  });
+
+  // Delegated: both the rail's Run button and the error card's Retry button
+  // carry data-action="run" — the latter only exists after a re-render, so
+  // it can't have a listener attached directly.
+  document.body.addEventListener("click", (e) => {
+    if (e.target.closest('[data-action="run"]')) runAnalysis();
+  });
+
+  render();
+  runAnalysis();
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2,9 +2,10 @@
  * MarkoWizard — analytical workstation.
  *
  * Owns the control-rail state (universe, history window, risk-free rate),
- * the KPI band, and the efficient-frontier chart. The rest of the report
- * (allocation, correlation, per-asset statistics, saved runs) lands in
- * later PRs and will read from the same `state` object this file sets up.
+ * the KPI band, the efficient-frontier chart, and the allocation donut/cash
+ * blend/weights table. The rest of the report (correlation, per-asset
+ * statistics, saved runs) lands in later PRs and will read from the same
+ * `state` object this file sets up.
  *
  * No framework, no build step — plain DOM, matching the rest of the repo.
  */
@@ -138,6 +139,26 @@ function selectedPortfolio() {
   return state.result.efficient_frontier[iF];
 }
 
+/** Blends the selected portfolio with cash: a plain weighted average, valid
+ * for whatever point is currently selected — not the theoretical capital
+ * allocation line specifically, which (by construction) only dominates the
+ * frontier when it's anchored at the tangency portfolio. The backend's
+ * `capital_allocation_line` is fixed to the tangency portfolio for exactly
+ * that reason, so it can't be reused here once the frontier selection (PR 4)
+ * has moved off tangency; this local formula is what the design handoff's
+ * own prototype uses too, for any selected point, not just the tangency
+ * case the README's "prefer the API's CAL" note assumed. Sharpe is
+ * unaffected by a cash blend, so callers that need it just read `p.sharpe`
+ * directly. */
+function cashBlend(p) {
+  const cashP = state.cash / 100;
+  const rf = rfOf(state.appliedRfIdx);
+  return {
+    expectedReturn: cashP * rf + (1 - cashP) * p.expected_return,
+    risk: (1 - cashP) * p.risk,
+  };
+}
+
 async function runAnalysis() {
   if (state.running) return;
   state.running = true;
@@ -221,15 +242,19 @@ function kpiSectionHtml() {
   const periodWords = PERIOD_WORDS[state.appliedPeriod] || state.appliedPeriod;
   const lede =
     `Estimated from ${periodWords} monthly history at a ${pct(toReturn(rfOf(state.appliedRfIdx)))} ` +
-    `${unitWord} risk-free rate. Fully invested in the risky portfolio.`;
+    `${unitWord} risk-free rate. ` +
+    (state.cash > 0
+      ? `Figures below include a ${state.cash}% cash position.`
+      : "Fully invested in the risky portfolio.");
 
   const weights = Object.values(p.weights);
   const holdings = weights.filter((w) => w > 0.005).length;
   const diversification = 1 / weights.reduce((a, w) => a + w * w, 0);
+  const blend = cashBlend(p);
 
   const kpis = [
-    { label: "Expected return", value: pct(toReturn(p.expected_return)), note: unitWord },
-    { label: "Volatility", value: pct(toVol(p.risk)), note: "standard deviation" },
+    { label: "Expected return", value: pct(toReturn(blend.expectedReturn)), note: unitWord },
+    { label: "Volatility", value: pct(toVol(blend.risk)), note: "standard deviation" },
     { label: "Sharpe ratio", value: toSharpe(p.sharpe).toFixed(2), note: "unchanged by the cash blend", accent: true },
     { label: "Holdings", value: String(holdings), note: `of ${n} assets, non-zero weight` },
     { label: "Diversification", value: diversification.toFixed(1), note: "effective assets held" },
@@ -535,6 +560,166 @@ function renderFrontier() {
   updateFrontierSelection();
 }
 
+/* ── Optimal allocation ──────────────────────────────────────────────── */
+
+const DONUT_CIRCUMFERENCE = 2 * Math.PI * 52;
+
+function nameFor(ticker) {
+  return UNIVERSE.find((u) => u.t === ticker)?.n || ticker;
+}
+
+// Only the row identity (tickers/names/colors, from `result.tickers`) is
+// "base" — it never changes for a given result, regardless of frontier
+// selection, cash or units. Everything else (weights, bar widths, the donut,
+// the blended figures) is recomputed on every render into allocationUpdate().
+let allocationBaseResult = null;
+
+function allocationRowsHtml(result) {
+  const p = selectedPortfolio();
+  const cashP = state.cash / 100;
+
+  const rows = result.tickers.map((t, k) => {
+    const w = p.weights[t] ?? 0;
+    return {
+      ticker: t,
+      name: nameFor(t),
+      color: CHART_PALETTE[k % CHART_PALETTE.length],
+      w,
+      capPct: w * (1 - cashP) * 100,
+    };
+  });
+
+  const cols = "104px minmax(0,1fr) 104px minmax(90px,22%) 104px";
+  const assetRows = rows.map((r) => `
+    <div class="mw-grid-row mw-grid-row--body" style="grid-template-columns:${cols}">
+      <span class="mw-swatch"><span class="mw-swatch__dot" style="background:${r.color}"></span>${escapeHtml(r.ticker)}</span>
+      <span class="text-muted" style="font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${escapeHtml(r.name)}</span>
+      <span class="mw-num" style="text-align:right">${pct(r.w, 1)}</span>
+      <span class="mw-bar-track"><span class="mw-bar-fill" style="width:${r.capPct.toFixed(2)}%;background:${r.color}"></span></span>
+      <span class="mw-num" style="text-align:right">${pct(r.capPct / 100, 1)}</span>
+    </div>`).join("");
+
+  const cashRow = `
+    <div class="mw-grid-row mw-grid-row--body" style="grid-template-columns:${cols}">
+      <span class="mw-swatch" style="color:var(--color-neutral-400)"><span class="mw-swatch__dot" style="background:var(--color-neutral-700)"></span>CASH</span>
+      <span class="text-muted" style="font-size:13px">Risk-free</span>
+      <span class="text-muted mw-num" style="text-align:right">—</span>
+      <span class="mw-bar-track"><span class="mw-bar-fill" style="width:${state.cash}%;background:var(--color-neutral-700)"></span></span>
+      <span class="mw-num" style="text-align:right">${state.cash}%</span>
+    </div>`;
+
+  return assetRows + cashRow;
+}
+
+function allocationArcsHtml(result) {
+  const p = selectedPortfolio();
+  const cashP = state.cash / 100;
+  let acc = 0;
+  return result.tickers
+    .map((t, k) => ({ w: p.weights[t] ?? 0, color: CHART_PALETTE[k % CHART_PALETTE.length] }))
+    .filter((r) => r.w > 0.0005)
+    .map((r) => {
+      const len = r.w * (1 - cashP) * DONUT_CIRCUMFERENCE;
+      const dash = `${len.toFixed(1)} ${(DONUT_CIRCUMFERENCE - len).toFixed(1)}`;
+      const offset = (-acc).toFixed(1);
+      acc += len;
+      return `<circle cx="64" cy="64" r="52" fill="none" stroke="${r.color}" stroke-width="13" stroke-dasharray="${dash}" stroke-dashoffset="${offset}" transform="rotate(-90 64 64)"></circle>`;
+    })
+    .join("");
+}
+
+function allocationBaseHtml(result) {
+  return `
+    <section id="allocation">
+      <h6 style="color:var(--color-accent-300)">02 · Holdings</h6>
+      <h3 style="margin-bottom:var(--space-2)">Optimal allocation</h3>
+      <p class="text-muted mw-section-lede">Weights for the selected portfolio. Blending with cash walks down the
+        capital allocation line: return and risk both scale, the Sharpe ratio does not move.</p>
+
+      <div class="mw-alloc-row">
+        <div class="card elev-sm mw-alloc-donut-card">
+          <div class="mw-alloc-donut">
+            <svg viewBox="0 0 128 128">
+              <circle cx="64" cy="64" r="52" fill="none" stroke="var(--color-neutral-800)" stroke-width="13"></circle>
+              <g id="mw-alloc-arcs"></g>
+            </svg>
+            <div class="mw-alloc-donut__overlay" id="mw-alloc-overlay"></div>
+          </div>
+          <div class="text-muted mw-alloc-donut__note" id="mw-alloc-note"></div>
+        </div>
+
+        <div class="mw-alloc-main">
+          <div class="card elev-sm mw-cash-card">
+            <div class="mw-cash-card__head">
+              <span class="card-kicker">Blend with cash</span>
+              <span class="mw-cash-card__pct" id="mw-cash-pct"></span>
+            </div>
+            <input id="mw-cash" type="range" min="0" max="90" step="5" value="${state.cash}" />
+            <div class="text-muted" style="font-size:12px" id="mw-cal-note"></div>
+          </div>
+
+          <div class="card elev-sm mw-table">
+            <div class="mw-table__inner" style="min-width:520px">
+              <div class="mw-grid-row mw-grid-row--head" style="grid-template-columns:104px minmax(0,1fr) 104px minmax(90px,22%) 104px">
+                <span>Asset</span><span>Name</span><span style="text-align:right">In risky mix</span><span>Share of capital</span><span style="text-align:right">Of capital</span>
+              </div>
+              <div id="mw-alloc-rows"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>`;
+}
+
+function attachAllocationEvents() {
+  const cash = document.getElementById("mw-cash");
+  if (!cash) return;
+  cash.addEventListener("input", () => {
+    state.cash = +cash.value;
+    render();
+  });
+}
+
+/** Refreshes everything that depends on the selected portfolio, cash or
+ * units — the donut arcs, its center overlay, the cash caption, and the
+ * weights rows. Deliberately does not touch `#mw-cash` itself: this runs on
+ * every `input` event the slider fires, and replacing the slider element
+ * mid-drag would interrupt the browser's own drag gesture on it (the same
+ * class of bug the frontier chart's pointer capture has to avoid). */
+function updateAllocation() {
+  const p = selectedPortfolio();
+  const unitWord = isAnnual() ? "annualized" : "monthly";
+  const blend = cashBlend(p);
+
+  document.getElementById("mw-alloc-arcs").innerHTML = allocationArcsHtml(state.result);
+  document.getElementById("mw-alloc-overlay").innerHTML = `
+    <span class="mw-alloc-donut__value">${escapeHtml(pct(toReturn(blend.expectedReturn)))}</span>
+    <span class="text-muted" style="font-size:10.5px">expected · ${escapeHtml(unitWord)}</span>`;
+  setText("mw-alloc-note", state.cash > 0 ? `Risky mix at ${100 - state.cash}% of capital` : "Fully invested");
+  setText("mw-cash-pct", `${state.cash}%`);
+  setText(
+    "mw-cal-note",
+    `At ${state.cash}% cash: ${pct(toReturn(blend.expectedReturn))} expected return, ` +
+      `${pct(toVol(blend.risk))} volatility, Sharpe ${toSharpe(p.sharpe).toFixed(2)}.`,
+  );
+  document.getElementById("mw-alloc-rows").innerHTML = allocationRowsHtml(state.result);
+}
+
+function renderAllocation() {
+  const slot = document.getElementById("mw-allocation-slot");
+  if (!state.result || state.error) {
+    slot.innerHTML = "";
+    allocationBaseResult = null;
+    return;
+  }
+  if (state.result !== allocationBaseResult) {
+    slot.innerHTML = allocationBaseHtml(state.result);
+    attachAllocationEvents();
+    allocationBaseResult = state.result;
+  }
+  updateAllocation();
+}
+
 function renderKpiSlot() {
   const slot = document.getElementById("mw-kpi-slot");
   if (state.error) {
@@ -552,6 +737,7 @@ function render() {
   renderOverlay();
   renderKpiSlot();
   renderFrontier();
+  renderAllocation();
 }
 
 /* ── Event wiring ────────────────────────────────────────────────────── */

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,10 +1,10 @@
 /**
  * MarkoWizard — analytical workstation.
  *
- * Owns the control-rail state (universe, history window, risk-free rate) and
- * the KPI band. The rest of the report (frontier, allocation, correlation,
- * per-asset statistics, saved runs) lands in later PRs and will read from
- * the same `state` object this file sets up.
+ * Owns the control-rail state (universe, history window, risk-free rate),
+ * the KPI band, and the efficient-frontier chart. The rest of the report
+ * (allocation, correlation, per-asset statistics, saved runs) lands in
+ * later PRs and will read from the same `state` object this file sets up.
  *
  * No framework, no build step — plain DOM, matching the rest of the repo.
  */
@@ -23,6 +23,13 @@ const UNIVERSE = [
 ];
 
 const DEFAULT_SEL = [0, 1, 5, 7, 8]; // AAPL, MSFT, SPY, BND, GLD
+
+// Chart series order, assigned by position in the selection — shared by the
+// frontier's per-asset dots and (in later PRs) the allocation donut/table.
+const CHART_PALETTE = [
+  "#2fc7cc", "#001d63", "#008ea0", "#42d4d7", "#64748b",
+  "#2c4d9c", "#00424c", "#94a3b8", "#5f7cbd", "#cbd5e1",
+];
 
 const PERIOD_WORDS = {
   "1y": "1-year",
@@ -44,8 +51,8 @@ const state = {
   appliedSel: [...DEFAULT_SEL],
   appliedPeriod: "5y",
   appliedRfIdx: 8,
-  iF: null, // frontier selection; null = tangency (max Sharpe). Wired up in a later PR.
-  cash: 0, // cash blend; wired up in a later PR.
+  iF: null, // frontier selection; null = tangency (max Sharpe)
+  cash: 0, // cash blend; wired up in a later PR
   units: null, // null | 'annual'
   running: false,
   result: null,
@@ -76,6 +83,21 @@ function escapeHtml(s) {
     "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
   })[c]);
 }
+function setText(id, text) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = text;
+}
+/** "Nice" tick step for an axis running 0..max: the largest of 1/2/2.5/5 x
+ * 10^n that still gives at least 4 ticks. Same rule the design handoff's
+ * prototype uses, so frontier tick counts match the reference screenshots. */
+function niceTickValues(max) {
+  const raw = max / 4;
+  const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+  const step = [1, 2, 2.5, 5, 10].map((m) => m * mag).find((s) => s >= raw) || mag * 10;
+  const out = [];
+  for (let v = 0; v <= max + 1e-9; v += step) out.push(v);
+  return out;
+}
 
 function isStale() {
   return (
@@ -85,13 +107,35 @@ function isStale() {
   );
 }
 
+/** Resolves `state.iF` against the current result: the effective frontier
+ * index, the tangency (max-Sharpe) index, and the descriptive label the
+ * design handoff uses for both the frontier stats panel and the KPI
+ * headline. `efficient_frontier[best]` and `max_sharpe_portfolio` are the
+ * same row from the backend's optimizer output, just serialized twice —
+ * reading through the frontier array here keeps a single source of truth
+ * for "which point is selected". */
+function resolveSelection(result) {
+  const pts = result.efficient_frontier;
+  const best = pts.reduce(
+    (b, p, i) => ((p.sharpe ?? -Infinity) > (pts[b].sharpe ?? -Infinity) ? i : b),
+    0,
+  );
+  const iF = state.iF == null ? best : Math.max(0, Math.min(pts.length - 1, state.iF));
+  let label;
+  if (iF === best) label = "Tangency portfolio — maximum Sharpe";
+  else if (iF === 0) label = "Minimum-variance portfolio";
+  else if (iF < best) label = "Below tangency — risk-averse";
+  else if (iF > pts.length - 5) label = "Frontier edge — single-asset concentration";
+  else label = "Above tangency — return-seeking";
+  return { iF, best, label, isBest: iF === best };
+}
+
 /** The portfolio the KPI band (and, later, the rest of the report) reads
- * from. `iF` isn't selectable yet (that's the frontier chart's job, PR 4),
- * so this always resolves to the tangency portfolio for now. */
+ * from. */
 function selectedPortfolio() {
   if (!state.result) return null;
-  if (state.iF == null) return state.result.max_sharpe_portfolio;
-  return state.result.efficient_frontier[state.iF];
+  const { iF } = resolveSelection(state.result);
+  return state.result.efficient_frontier[iF];
 }
 
 async function runAnalysis() {
@@ -172,7 +216,8 @@ function kpiSectionHtml() {
   const unitWord = isAnnual() ? "annualized" : "monthly";
   const n = state.appliedSel.length;
 
-  const headline = `The best risk-adjusted mix of your ${n} asset${n === 1 ? "" : "s"}`;
+  const { label, isBest } = resolveSelection(state.result);
+  const headline = isBest ? `The best risk-adjusted mix of your ${n} asset${n === 1 ? "" : "s"}` : label;
   const periodWords = PERIOD_WORDS[state.appliedPeriod] || state.appliedPeriod;
   const lede =
     `Estimated from ${periodWords} monthly history at a ${pct(toReturn(rfOf(state.appliedRfIdx)))} ` +
@@ -215,6 +260,281 @@ function errorCardHtml() {
     </div>`;
 }
 
+/* ── Efficient frontier ──────────────────────────────────────────────── */
+
+// SVG plot box, per the handoff: viewBox 0 0 880 470, x from 62 to 862
+// (zero at 62), y from 404 (zero) up to 26.
+const FR_X0 = 62;
+const FR_X_SPAN = 800;
+const FR_Y0 = 404;
+const FR_Y_SPAN = 378;
+
+// Rebuilt only when `state.result` changes (a new run) — holds the scale
+// functions and point coordinates the base SVG and the selection overlay
+// both read. Recomputing this on every drag frame would be wasteful and,
+// worse, would mean tearing down the SVG element mid-drag and losing its
+// pointer capture (see renderFrontier below).
+let frontierGeo = null;
+let frontierBaseResult = null;
+let frontierBaseUnits = null;
+
+function computeFrontierGeometry(result) {
+  const pts = result.efficient_frontier;
+  const assetStats = result.asset_statistics || [];
+  const xMax = Math.max(...pts.map((q) => q.risk), ...assetStats.map((a) => a.volatility)) * 1.08;
+  const yMax =
+    Math.max(...pts.map((q) => q.expected_return), ...assetStats.map((a) => a.expected_return)) * 1.12;
+  const X = (v) => FR_X0 + (v / xMax) * FR_X_SPAN;
+  const Y = (v) => FR_Y0 - (v / yMax) * FR_Y_SPAN;
+  const geo = pts.map((q) => ({ cx: +X(q.risk).toFixed(1), cy: +Y(q.expected_return).toFixed(1) }));
+  return { pts, assetStats, xMax, yMax, X, Y, geo };
+}
+
+/** Maps a pointer event's x position to the nearest frontier point by risk,
+ * accounting for the plot box's left inset — not a naive fraction of the
+ * SVG element's width. */
+function pickFrontierPoint(evt, svgEl) {
+  const rect = svgEl.getBoundingClientRect();
+  const t = Math.max(
+    0,
+    Math.min(1, (evt.clientX - rect.left - (FR_X0 / 880) * rect.width) / ((FR_X_SPAN / 880) * rect.width)),
+  );
+  const target = t * frontierGeo.xMax;
+  let bestIdx = 0;
+  let bestDist = Infinity;
+  frontierGeo.pts.forEach((q, i) => {
+    const d = Math.abs(q.risk - target);
+    if (d < bestDist) {
+      bestDist = d;
+      bestIdx = i;
+    }
+  });
+  state.iF = bestIdx;
+  render();
+}
+
+function frontierSectionHtml(result) {
+  const geo = frontierGeo;
+  const rf = rfOf(state.appliedRfIdx);
+  const { best } = resolveSelection(result);
+
+  const gridPath = niceTickValues(geo.yMax).map((v) => `M${FR_X0} ${geo.Y(v).toFixed(1)}H862`).join(" ");
+  const xTickPath = niceTickValues(geo.xMax).map((v) => `M${geo.X(v).toFixed(1)} ${FR_Y0}v7`).join(" ");
+  const dotsPath = geo.geo
+    .map((g) => `M${(g.cx - 2.2).toFixed(1)} ${g.cy}a2.2 2.2 0 1 0 4.4 0a2.2 2.2 0 1 0 -4.4 0`)
+    .join(" ");
+  const line = geo.geo.map((g) => `${g.cx},${g.cy}`).join(" ");
+  const mvp = geo.geo[0];
+  const tan = geo.geo[best];
+
+  const tanPoint = geo.pts[best];
+  const slope = (tanPoint.expected_return - rf) / tanPoint.risk;
+  let calX = geo.xMax;
+  let calY = rf + slope * calX;
+  if (calY > geo.yMax) {
+    calY = geo.yMax;
+    calX = (geo.yMax - rf) / slope;
+  }
+  const cal = {
+    x1: geo.X(0).toFixed(1), y1: geo.Y(rf).toFixed(1),
+    x2: geo.X(calX).toFixed(1), y2: geo.Y(calY).toFixed(1),
+    pctX: (((geo.X(calX) - 6) / 880) * 100).toFixed(2),
+    pctY: (((geo.Y(calY) + 6) / 470) * 100).toFixed(2),
+  };
+
+  const unitWord = isAnnual() ? "annualized" : "monthly";
+  const yTicks = niceTickValues(geo.yMax).map((v) => ({
+    pctY: ((geo.Y(v) / 470) * 100).toFixed(2),
+    label: pct(toReturn(v), isAnnual() ? 0 : 1),
+  }));
+  const xTicks = niceTickValues(geo.xMax).map((v) => ({
+    pctX: ((geo.X(v) / 880) * 100).toFixed(2),
+    label: pct(toVol(v), isAnnual() ? 0 : 1),
+  }));
+
+  const statsByTicker = Object.fromEntries(geo.assetStats.map((a) => [a.ticker, a]));
+  const assetDots = result.tickers
+    .map((t, k) => {
+      const a = statsByTicker[t];
+      if (!a) return null; // shouldn't happen — every requested ticker gets stats back
+      return {
+        t,
+        color: CHART_PALETTE[k % CHART_PALETTE.length],
+        pctX: ((geo.X(a.volatility) / 880) * 100).toFixed(2),
+        pctY: ((geo.Y(a.expected_return) / 470) * 100).toFixed(2),
+      };
+    })
+    .filter(Boolean);
+
+  return `
+    <section id="frontier">
+      <h6 style="color:var(--color-accent-300)">01 · Risk–return</h6>
+      <h3 style="margin-bottom:var(--space-2)">Efficient frontier</h3>
+      <p class="text-muted mw-section-lede">Every point is a portfolio the optimizer can build from your
+        ${result.tickers.length} assets. Click or drag along the curve to move the selection — the whole
+        report above follows it.</p>
+
+      <div class="mw-frontier-row">
+        <div class="card elev-sm mw-frontier-chart-card">
+          <div class="mw-frontier-plot">
+            <svg id="mw-frontier-svg" class="mw-frontier-svg" viewBox="0 0 880 470">
+              <path d="${gridPath}" fill="none" stroke="var(--color-neutral-900)" stroke-width="1"></path>
+              <path d="${xTickPath}" fill="none" stroke="var(--color-neutral-600)" stroke-width="1"></path>
+              <line x1="${FR_X0}" y1="${FR_Y0}" x2="862" y2="${FR_Y0}" stroke="var(--color-neutral-500)" stroke-width="1"></line>
+              <line x1="${cal.x1}" y1="${cal.y1}" x2="${cal.x2}" y2="${cal.y2}" stroke="var(--color-accent-300)" stroke-width="1.4" stroke-dasharray="6 5"></line>
+              <polyline points="${line}" fill="none" stroke="var(--color-accent-400)" stroke-width="2.6" stroke-linejoin="round"></polyline>
+              <path d="${dotsPath}" fill="var(--color-accent-300)" opacity="0.55"></path>
+              <circle cx="${mvp.cx}" cy="${mvp.cy}" r="4.5" fill="var(--color-bg)" stroke="var(--color-neutral-400)" stroke-width="1.8"></circle>
+              <circle cx="${tan.cx}" cy="${tan.cy}" r="6" fill="var(--color-bg)" stroke="var(--color-accent-200)" stroke-width="2.2"></circle>
+              <line id="mw-fr-cross-h" x1="${FR_X0}" y1="0" x2="0" y2="0" stroke="var(--color-accent)" stroke-width="1" stroke-dasharray="3 4" opacity="0.55"></line>
+              <line id="mw-fr-cross-v" x1="0" y1="0" x2="0" y2="${FR_Y0}" stroke="var(--color-accent)" stroke-width="1" stroke-dasharray="3 4" opacity="0.55"></line>
+              <circle id="mw-fr-sel-halo" cx="0" cy="0" r="12" fill="var(--color-accent)" opacity="0.18"></circle>
+              <circle id="mw-fr-sel-dot" cx="0" cy="0" r="6" fill="var(--color-accent)" stroke="var(--color-bg)" stroke-width="2"></circle>
+            </svg>
+            <div class="mw-frontier-overlay">
+              ${yTicks.map((t) => `<span style="left:0;width:5.9%;text-align:right;top:${t.pctY}%;transform:translateY(-50%)">${t.label}</span>`).join("")}
+              ${xTicks.map((t) => `<span style="left:${t.pctX}%;top:88.5%;transform:translateX(-50%)">${t.label}</span>`).join("")}
+              ${assetDots.map((a) => `
+                <span style="left:${a.pctX}%;top:${a.pctY}%;transform:translate(9px,-50%);font-size:12.5px;color:var(--color-neutral-300)">${escapeHtml(a.t)}</span>
+                <span style="left:${a.pctX}%;top:${a.pctY}%;transform:translate(-50%,-50%);width:9px;height:9px;border-radius:50%;border:2px solid ${a.color};background:var(--color-bg)"></span>`).join("")}
+              <span style="left:52.5%;top:95.5%;transform:translateX(-50%);font-size:13px;color:var(--color-neutral-300)">Volatility σ →</span>
+              <span style="left:7.4%;top:4.5%;font-size:13px;color:var(--color-neutral-300)">↑ Expected return · ${unitWord}</span>
+              <span style="left:${cal.pctX}%;top:${cal.pctY}%;transform:translate(-100%,14px);font-size:12.5px;color:var(--color-accent-300)">Capital allocation line</span>
+            </div>
+          </div>
+          <div class="mw-frontier-legend">
+            <span class="text-muted mw-legend-item"><span style="width:16px;height:2px;background:var(--color-accent-400);display:block"></span>Frontier</span>
+            <span class="text-muted mw-legend-item"><span style="width:10px;height:10px;border-radius:50%;border:2px solid var(--color-accent-200);display:block"></span>Tangency</span>
+            <span class="text-muted mw-legend-item"><span style="width:9px;height:9px;border-radius:50%;border:1.6px solid var(--color-neutral-400);display:block"></span>Minimum variance</span>
+            <span class="text-muted mw-legend-item"><span style="width:9px;height:9px;border-radius:50%;border:1.8px solid var(--color-neutral-500);display:block"></span>Single asset</span>
+          </div>
+        </div>
+
+        <div class="card elev-sm mw-frontier-stats">
+          <div>
+            <span class="card-kicker">Selected portfolio</span>
+            <div class="mw-frontier-stats__title" id="mw-fr-title"></div>
+          </div>
+          <div class="mw-frontier-stats__rows">
+            <div class="mw-frontier-stats__row"><span class="text-muted" style="font-size:12px">Expected return</span><span class="mw-frontier-stats__row-value" id="mw-fr-row-return"></span></div>
+            <div class="mw-frontier-stats__row"><span class="text-muted" style="font-size:12px">Volatility</span><span class="mw-frontier-stats__row-value" id="mw-fr-row-risk"></span></div>
+            <div class="mw-frontier-stats__row"><span class="text-muted" style="font-size:12px">Sharpe ratio</span><span class="mw-frontier-stats__row-value" style="color:var(--color-accent-300)" id="mw-fr-row-sharpe"></span></div>
+            <div class="mw-frontier-stats__row"><span class="text-muted" style="font-size:12px">Largest position</span><span class="mw-frontier-stats__row-value" id="mw-fr-row-largest"></span></div>
+          </div>
+          <p class="card-body" id="mw-fr-tip"></p>
+          <div style="display:flex;gap:var(--space-2)">
+            <button type="button" class="btn btn-secondary" data-action="frontier-mvp" style="flex:1">Min variance</button>
+            <button type="button" class="btn btn-primary" data-action="frontier-tan" style="flex:1">Max Sharpe</button>
+          </div>
+        </div>
+      </div>
+    </section>`;
+}
+
+function attachFrontierEvents() {
+  const svg = document.getElementById("mw-frontier-svg");
+  if (!svg) return;
+  svg.addEventListener("pointerdown", (e) => {
+    try {
+      if (e.pointerId != null) svg.setPointerCapture(e.pointerId);
+    } catch {
+      // Synthetic events (and some test harnesses) may lack a real pointerId.
+    }
+    svg._mwDragging = true;
+    pickFrontierPoint(e, svg);
+  });
+  svg.addEventListener("pointermove", (e) => {
+    if (svg._mwDragging) pickFrontierPoint(e, svg);
+  });
+  svg.addEventListener("pointerup", () => {
+    svg._mwDragging = false;
+  });
+  svg.addEventListener("pointercancel", () => {
+    svg._mwDragging = false;
+  });
+}
+
+/** Updates only the selection-dependent bits (crosshair, marker, stats
+ * panel) without touching the SVG element itself — rebuilding it mid-drag
+ * would drop the pointer capture attachFrontierEvents just set up. */
+function updateFrontierSelection() {
+  if (!state.result || !frontierGeo) return;
+  const { iF, best, label, isBest } = resolveSelection(state.result);
+  const p = frontierGeo.pts[iF];
+  const g = frontierGeo.geo[iF];
+
+  const crossH = document.getElementById("mw-fr-cross-h");
+  const crossV = document.getElementById("mw-fr-cross-v");
+  const halo = document.getElementById("mw-fr-sel-halo");
+  const dot = document.getElementById("mw-fr-sel-dot");
+  if (crossH) {
+    crossH.setAttribute("x2", g.cx);
+    crossH.setAttribute("y1", g.cy);
+    crossH.setAttribute("y2", g.cy);
+  }
+  if (crossV) {
+    crossV.setAttribute("x1", g.cx);
+    crossV.setAttribute("x2", g.cx);
+    crossV.setAttribute("y1", g.cy);
+  }
+  if (halo) {
+    halo.setAttribute("cx", g.cx);
+    halo.setAttribute("cy", g.cy);
+  }
+  if (dot) {
+    dot.setAttribute("cx", g.cx);
+    dot.setAttribute("cy", g.cy);
+  }
+
+  setText("mw-fr-title", label);
+  setText("mw-fr-row-return", pct(toReturn(p.expected_return)));
+  setText("mw-fr-row-risk", pct(toVol(p.risk)));
+  setText("mw-fr-row-sharpe", toSharpe(p.sharpe).toFixed(3));
+
+  const [largestTicker, largestWeight] = Object.entries(p.weights).reduce(
+    (a, [t, w]) => (w > a[1] ? [t, w] : a),
+    ["—", -Infinity],
+  );
+  setText("mw-fr-row-largest", `${largestTicker} · ${(largestWeight * 100).toFixed(0)}%`);
+
+  setText(
+    "mw-fr-tip",
+    isBest
+      ? "This is where the capital allocation line touches the frontier: no other long-only mix of these assets pays more return per unit of risk."
+      : iF < best
+        ? "Safer than the tangency portfolio, but every unit of risk here buys less return. Blending the tangency mix with cash dominates this point."
+        : "Past tangency the curve flattens: additional return costs more volatility than it returns. Low-volatility assets have dropped out.",
+  );
+}
+
+function renderFrontier() {
+  const slot = document.getElementById("mw-frontier-slot");
+  // A failed re-run leaves the previous `state.result` in place (see
+  // runAnalysis) so a transient failure doesn't blow away a working report;
+  // but showing a stale chart under the error card would be confusing, so
+  // the error card (in the KPI slot) takes over the whole report area.
+  if (!state.result || state.error) {
+    slot.innerHTML = "";
+    frontierGeo = null;
+    frontierBaseResult = null;
+    frontierBaseUnits = null;
+    return;
+  }
+  // Units (monthly/annual) change the axis titles and tick labels, which are
+  // baked into the static HTML below — not just the selection-dependent
+  // bits updateFrontierSelection touches — so a units change needs a base
+  // rebuild too. That's safe here (unlike mid-drag) because toggling units
+  // is a discrete click, never a pointermove while the SVG holds capture.
+  if (state.result !== frontierBaseResult || state.units !== frontierBaseUnits) {
+    frontierGeo = computeFrontierGeometry(state.result);
+    slot.innerHTML = frontierSectionHtml(state.result);
+    attachFrontierEvents();
+    frontierBaseResult = state.result;
+    frontierBaseUnits = state.units;
+  }
+  updateFrontierSelection();
+}
+
 function renderKpiSlot() {
   const slot = document.getElementById("mw-kpi-slot");
   if (state.error) {
@@ -231,6 +551,7 @@ function render() {
   renderChips();
   renderOverlay();
   renderKpiSlot();
+  renderFrontier();
 }
 
 /* ── Event wiring ────────────────────────────────────────────────────── */
@@ -265,11 +586,19 @@ function init() {
     render();
   });
 
-  // Delegated: both the rail's Run button and the error card's Retry button
-  // carry data-action="run" — the latter only exists after a re-render, so
-  // it can't have a listener attached directly.
+  // Delegated: the rail's Run button, the error card's Retry button, and the
+  // frontier stats panel's jump buttons are all rebuilt on every re-render,
+  // so none of them can have a listener attached directly.
   document.body.addEventListener("click", (e) => {
     if (e.target.closest('[data-action="run"]')) runAnalysis();
+    if (e.target.closest('[data-action="frontier-mvp"]')) {
+      state.iF = 0;
+      render();
+    }
+    if (e.target.closest('[data-action="frontier-tan"]')) {
+      state.iF = null;
+      render();
+    }
   });
 
   render();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2,10 +2,10 @@
  * MarkoWizard — analytical workstation.
  *
  * Owns the control-rail state (universe, history window, risk-free rate),
- * the KPI band, the efficient-frontier chart, and the allocation donut/cash
- * blend/weights table. The rest of the report (correlation, per-asset
- * statistics, saved runs) lands in later PRs and will read from the same
- * `state` object this file sets up.
+ * the KPI band, the efficient-frontier chart, the allocation donut/cash
+ * blend/weights table, the correlation matrix, and per-asset statistics.
+ * Saved runs lands in a later PR and will read from the same `state`
+ * object this file sets up.
  *
  * No framework, no build step — plain DOM, matching the rest of the repo.
  */
@@ -720,6 +720,145 @@ function renderAllocation() {
   updateAllocation();
 }
 
+/* ── Correlation matrix ──────────────────────────────────────────────── */
+
+// Linear RGB interpolation from neutral-900 (0.0) to accent-600 (1.0). Text
+// stays ink-dark at every value — the ramp tops out light enough that a
+// contrast threshold (needed in the mobile design this superseded) isn't
+// needed here.
+const CORR_LOW_RGB = [241, 245, 249];
+const CORR_HIGH_RGB = [94, 213, 217];
+
+function correlationCellColor(v) {
+  const t = Math.max(0, Math.min(1, v));
+  const rgb = CORR_LOW_RGB.map((u, k) => Math.round(u + (CORR_HIGH_RGB[k] - u) * t));
+  return `rgb(${rgb.join(",")})`;
+}
+
+function correlationSectionHtml(result) {
+  const tickers = result.tickers;
+  const corr = result.correlation_matrix;
+
+  const heads = tickers
+    .map((t) => `<span style="text-align:center;font-size:11px;font-family:var(--font-heading);color:var(--color-neutral-400);padding-bottom:2px">${escapeHtml(t)}</span>`)
+    .join("");
+
+  const rows = tickers
+    .map((rowTicker, i) => {
+      const label = `<span style="display:flex;align-items:center;font-size:11.5px;font-family:var(--font-heading);color:var(--color-neutral-300)">${escapeHtml(rowTicker)}</span>`;
+      const cells = tickers
+        .map((_, j) => {
+          const v = corr[i][j];
+          return `<span style="aspect-ratio:1/1;border-radius:var(--radius-sm);display:flex;align-items:center;justify-content:center;font-size:11.5px;font-variant-numeric:tabular-nums;background:${correlationCellColor(v)};color:#0d1321">${v.toFixed(2)}</span>`;
+        })
+        .join("");
+      return label + cells;
+    })
+    .join("");
+
+  // Least/most correlated pair, scanning the upper triangle only (each pair once).
+  let lo = { v: 2, a: 0, b: 0 };
+  let hi = { v: -2, a: 0, b: 0 };
+  for (let i = 0; i < tickers.length; i++) {
+    for (let j = i + 1; j < tickers.length; j++) {
+      const v = corr[i][j];
+      if (v < lo.v) lo = { v, a: i, b: j };
+      if (v > hi.v) hi = { v, a: i, b: j };
+    }
+  }
+
+  const matrixMin = 58 + tickers.length * 41;
+  const periodWords = state.appliedPeriod === "max" ? "all available history" : state.appliedPeriod.replace("y", " years");
+
+  return `
+    <section id="correlation">
+      <h6 style="color:var(--color-accent-300)">03 · Diversification</h6>
+      <h3 style="margin-bottom:var(--space-2)">Correlation matrix</h3>
+      <p class="text-muted mw-section-lede">Pairwise correlation of monthly returns over ${escapeHtml(periodWords)}.
+        Low pairs are what let the optimizer cut risk without giving up return.</p>
+
+      <div class="mw-corr-row">
+        <div class="card elev-sm mw-corr-matrix-card">
+          <div class="mw-corr-grid" style="grid-template-columns:58px repeat(${tickers.length},minmax(38px,54px));min-width:${matrixMin}px">
+            <span></span>
+            ${heads}
+            ${rows}
+          </div>
+          <div class="mw-corr-legend">
+            <span class="text-muted" style="font-size:11px">0.0</span>
+            <span class="mw-corr-legend__bar"></span>
+            <span class="text-muted" style="font-size:11px">1.0</span>
+          </div>
+        </div>
+
+        <div class="card elev-sm mw-corr-callout">
+          <span class="card-kicker">Least correlated pair</span>
+          <div class="mw-corr-callout__pair">${escapeHtml(tickers[lo.a])} · ${escapeHtml(tickers[lo.b])}</div>
+          <div class="mw-corr-callout__value">${lo.v.toFixed(2)}</div>
+          <p class="card-body">Two assets that rarely move together reduce portfolio variance without reducing
+            expected return, which is why the optimizer holds both even when one has the weaker standalone record.</p>
+          <div class="mw-corr-callout__footer">
+            <span class="text-muted" style="font-size:12px">Most correlated</span>
+            <span style="font-family:var(--font-heading);font-size:13px">${escapeHtml(tickers[hi.a])} · ${escapeHtml(tickers[hi.b])} · ${hi.v.toFixed(2)}</span>
+          </div>
+        </div>
+      </div>
+    </section>`;
+}
+
+function renderCorrelation() {
+  const slot = document.getElementById("mw-correlation-slot");
+  slot.innerHTML = state.result && !state.error ? correlationSectionHtml(state.result) : "";
+}
+
+/* ── Per-asset statistics ────────────────────────────────────────────── */
+
+function assetStatsSectionHtml(result) {
+  const p = selectedPortfolio();
+  const rf = rfOf(state.appliedRfIdx);
+  const statsByTicker = Object.fromEntries((result.asset_statistics || []).map((a) => [a.ticker, a]));
+  const cols = "104px minmax(0,1fr) 124px 104px 136px 96px";
+
+  const rows = result.tickers
+    .map((t, k) => {
+      const a = statsByTicker[t];
+      const w = p.weights[t] ?? 0;
+      const standaloneSharpe = (a.expected_return - rf) / a.volatility;
+      const wColor = w > 0.005 ? "var(--color-text)" : "var(--color-neutral-600)";
+      return `
+        <div class="mw-grid-row mw-grid-row--body" style="grid-template-columns:${cols}">
+          <span class="mw-swatch"><span class="mw-swatch__dot" style="background:${CHART_PALETTE[k % CHART_PALETTE.length]}"></span>${escapeHtml(t)}</span>
+          <span class="text-muted" style="font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${escapeHtml(nameFor(t))}</span>
+          <span class="mw-num" style="text-align:right">${pct(toReturn(a.expected_return))}</span>
+          <span class="mw-num" style="text-align:right">${pct(toVol(a.volatility))}</span>
+          <span class="mw-num" style="text-align:right;color:var(--color-neutral-400)">${toSharpe(standaloneSharpe).toFixed(2)}</span>
+          <span class="mw-num" style="text-align:right;color:${wColor}">${pct(w, 1)}</span>
+        </div>`;
+    })
+    .join("");
+
+  return `
+    <section id="assets">
+      <h6 style="color:var(--color-accent-300)">04 · Inputs</h6>
+      <h3 style="margin-bottom:var(--space-2)">Per-asset statistics</h3>
+      <p class="text-muted mw-section-lede">What the optimizer was given. A high standalone Sharpe does not guarantee
+        a large weight — covariance decides.</p>
+      <div class="card elev-sm mw-table">
+        <div class="mw-table__inner" style="min-width:620px">
+          <div class="mw-grid-row mw-grid-row--head" style="grid-template-columns:${cols}">
+            <span>Asset</span><span>Name</span><span style="text-align:right">Expected return</span><span style="text-align:right">Volatility</span><span style="text-align:right">Sharpe, standalone</span><span style="text-align:right">Weight</span>
+          </div>
+          ${rows}
+        </div>
+      </div>
+    </section>`;
+}
+
+function renderAssetStats() {
+  const slot = document.getElementById("mw-assets-slot");
+  slot.innerHTML = state.result && !state.error ? assetStatsSectionHtml(state.result) : "";
+}
+
 function renderKpiSlot() {
   const slot = document.getElementById("mw-kpi-slot");
   if (state.error) {
@@ -738,6 +877,8 @@ function render() {
   renderKpiSlot();
   renderFrontier();
   renderAllocation();
+  renderCorrelation();
+  renderAssetStats();
 }
 
 /* ── Event wiring ────────────────────────────────────────────────────── */

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,11 +1,12 @@
 /**
  * MarkoWizard — analytical workstation.
  *
- * Owns the control-rail state (universe, history window, risk-free rate),
- * the KPI band, the efficient-frontier chart, the allocation donut/cash
- * blend/weights table, the correlation matrix, and per-asset statistics.
- * Saved runs lands in a later PR and will read from the same `state`
- * object this file sets up.
+ * Owns the control-rail state (universe, history window, risk-free rate)
+ * and every report section: the KPI band, the efficient-frontier chart, the
+ * allocation donut/cash blend/weights table, the correlation matrix,
+ * per-asset statistics, and saved runs (localStorage-backed — saving was
+ * left undesigned in the handoff; see the comment above the saved-runs
+ * functions below).
  *
  * No framework, no build step — plain DOM, matching the rest of the repo.
  */
@@ -859,6 +860,150 @@ function renderAssetStats() {
   slot.innerHTML = state.result && !state.error ? assetStatsSectionHtml(state.result) : "";
 }
 
+/* ── Saved runs ──────────────────────────────────────────────────────────
+ * Not designed in the handoff — section 05 is fixtures only there ("saving
+ * is not implemented... see Gaps"). Everything below (the save action, the
+ * storage format, load/delete) is this project's own invention, built to
+ * the agreed v1 shape: kept in this browser's localStorage, no server
+ * changes. */
+
+const SAVED_RUNS_KEY = "markowizard.savedRuns";
+
+function loadSavedRuns() {
+  try {
+    const raw = localStorage.getItem(SAVED_RUNS_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    // Storage unavailable (private browsing, disabled, corrupted value) —
+    // degrade to "no saved runs" rather than breaking the report.
+    return [];
+  }
+}
+
+function writeSavedRuns(runs) {
+  try {
+    localStorage.setItem(SAVED_RUNS_KEY, JSON.stringify(runs));
+  } catch {
+    // Save silently doesn't persist (e.g. quota exceeded) — not worth a
+    // user-facing error for a convenience feature with no design spec.
+  }
+}
+
+function saveCurrentRun() {
+  if (!state.result || state.error) return;
+  const p = selectedPortfolio();
+  const periodLabel = state.appliedPeriod === "max" ? "Max" : state.appliedPeriod.toUpperCase();
+  const defaultName = `${state.appliedSel.length} assets · ${periodLabel}`;
+  const name = window.prompt("Name this saved run:", defaultName);
+  if (name === null) return; // cancelled
+
+  const runs = loadSavedRuns();
+  runs.unshift({
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    name: name.trim() || defaultName,
+    date: new Date().toLocaleString(undefined, {
+      month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
+    }),
+    sel: [...state.appliedSel],
+    period: state.appliedPeriod,
+    rfIdx: state.appliedRfIdx,
+    // Raw (pre-cash) selected-portfolio figures — cash is transient UI
+    // state, not part of the saved artifact, and resets to 0 on load just
+    // like it does on a fresh run.
+    expectedReturn: p.expected_return,
+    risk: p.risk,
+    sharpe: p.sharpe,
+  });
+  writeSavedRuns(runs);
+  render();
+}
+
+function loadSavedRun(id) {
+  const run = loadSavedRuns().find((r) => r.id === id);
+  if (!run) return;
+  state.sel = [...run.sel];
+  state.period = run.period;
+  state.rfIdx = run.rfIdx;
+  runAnalysis();
+}
+
+function deleteSavedRun(id) {
+  writeSavedRuns(loadSavedRuns().filter((r) => r.id !== id));
+  render();
+}
+
+function savedRunsSectionHtml() {
+  const runs = loadSavedRuns();
+  const canSave = !!state.result && !state.error;
+
+  const header = `
+    <div class="mw-saved-head">
+      <div>
+        <h6 style="color:var(--color-accent-300)">05 · History</h6>
+        <h3 style="margin-bottom:var(--space-2)">Saved runs</h3>
+        <p class="text-muted mw-section-lede" style="margin:0">Kept locally in this browser. Load one to replace
+          the report above.</p>
+      </div>
+      <button type="button" class="btn btn-primary" data-action="save-run" style="flex:none" ${canSave ? "" : "disabled"}>Save this run</button>
+    </div>`;
+
+  if (runs.length === 0) {
+    return `
+      <section id="saved">
+        ${header}
+        <div class="card elev-sm mw-placeholder">
+          <img src="assets/images/mascote-analise-de-dados.png" alt="" style="width:48px;height:48px;object-fit:contain" />
+          <p class="card-body">No saved runs yet — run an analysis, then save it to come back to it later.</p>
+        </div>
+      </section>`;
+  }
+
+  const cols = "minmax(0,1.1fr) minmax(0,1.6fr) 112px 92px 92px 80px 76px";
+  const rows = runs
+    .map((r) => {
+      const universe = r.sel.map((i) => UNIVERSE[i]?.t).filter(Boolean).join(" · ");
+      const windowLabel = (r.period === "max" ? "Max" : r.period.toUpperCase()) + " monthly";
+      return `
+        <div class="mw-grid-row mw-grid-row--body" style="grid-template-columns:${cols}">
+          <span style="display:flex;flex-direction:column">
+            <span style="font-family:var(--font-heading)">${escapeHtml(r.name)}</span>
+            <span class="text-muted" style="font-size:11px">${escapeHtml(r.date)}</span>
+          </span>
+          <span class="text-muted" style="font-size:12.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${escapeHtml(universe)}</span>
+          <span class="text-muted" style="font-size:12.5px">${escapeHtml(windowLabel)}</span>
+          <span class="mw-num" style="text-align:right">${pct(toReturn(r.expectedReturn))}</span>
+          <span class="mw-num" style="text-align:right">${pct(toVol(r.risk))}</span>
+          <span class="mw-num" style="text-align:right;color:var(--color-accent-300)">${toSharpe(r.sharpe).toFixed(2)}</span>
+          <span style="text-align:right;display:flex;gap:4px;justify-content:flex-end">
+            <button type="button" class="btn btn-ghost" data-action="load-run" data-run-id="${escapeHtml(r.id)}">Load</button>
+            <button type="button" class="btn btn-ghost" data-action="delete-run" data-run-id="${escapeHtml(r.id)}" title="Delete" aria-label="Delete saved run">✕</button>
+          </span>
+        </div>`;
+    })
+    .join("");
+
+  return `
+    <section id="saved">
+      ${header}
+      <div class="card elev-sm mw-table">
+        <div class="mw-table__inner" style="min-width:700px">
+          <div class="mw-grid-row mw-grid-row--head" style="grid-template-columns:${cols}">
+            <span>Run</span><span>Universe</span><span>Window</span><span style="text-align:right">Return</span><span style="text-align:right">Risk</span><span style="text-align:right">Sharpe</span><span></span>
+          </div>
+          ${rows}
+        </div>
+      </div>
+    </section>`;
+}
+
+// Unlike the other report sections, saved runs isn't gated on state.result:
+// it's a persistent list independent of whether the current run succeeded
+// (and it stays usable — Load included — even after a failed re-run).
+function renderSavedRuns() {
+  document.getElementById("mw-saved-slot").innerHTML = savedRunsSectionHtml();
+}
+
 function renderKpiSlot() {
   const slot = document.getElementById("mw-kpi-slot");
   if (state.error) {
@@ -879,6 +1024,7 @@ function render() {
   renderAllocation();
   renderCorrelation();
   renderAssetStats();
+  renderSavedRuns();
 }
 
 /* ── Event wiring ────────────────────────────────────────────────────── */
@@ -926,6 +1072,11 @@ function init() {
       state.iF = null;
       render();
     }
+    if (e.target.closest('[data-action="save-run"]')) saveCurrentRun();
+    const loadBtn = e.target.closest('[data-action="load-run"]');
+    if (loadBtn) loadSavedRun(loadBtn.dataset.runId);
+    const deleteBtn = e.target.closest('[data-action="delete-run"]');
+    if (deleteBtn) deleteSavedRun(deleteBtn.dataset.runId);
   });
 
   render();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -87,12 +87,10 @@
             <div id="mw-allocation-slot"></div>
             <div id="mw-correlation-slot"></div>
             <div id="mw-assets-slot"></div>
-            <div class="card elev-sm mw-placeholder">
-                <span class="card-kicker">Coming soon</span>
-                <p class="card-body">
-                    Saved runs is being rebuilt next — see the implementation plan for the staged PRs ahead.
-                </p>
-            </div>
+            <div id="mw-saved-slot"></div>
+            <p class="text-muted mw-disclaimer">Expected returns and covariances are estimated from historical
+                monthly closes and are not forecasts. Long-only, fully invested, no transaction costs or taxes.
+                MarkoWizard · Outliers Analytics.</p>
         </main>
     </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -85,11 +85,12 @@
             <div id="mw-kpi-slot"></div>
             <div id="mw-frontier-slot"></div>
             <div id="mw-allocation-slot"></div>
+            <div id="mw-correlation-slot"></div>
+            <div id="mw-assets-slot"></div>
             <div class="card elev-sm mw-placeholder">
                 <span class="card-kicker">Coming soon</span>
                 <p class="card-body">
-                    The rest of the report (correlation matrix, per-asset statistics and saved runs) is being
-                    rebuilt section by section — see the implementation plan for the staged PRs ahead.
+                    Saved runs is being rebuilt next — see the implementation plan for the staged PRs ahead.
                 </p>
             </div>
         </main>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,10 +18,10 @@
             <span class="mw-header__divider"></span>
             <img src="assets/markowizard-wordmark-light.svg" alt="MarkoWizard" />
         </a>
-        <span class="tag tag-neutral">AAPL · MSFT · SPY · BND · GLD</span>
-        <span class="tag tag-outline">5Y monthly</span>
-        <span class="text-muted" style="font-size: 12px">Not run yet</span>
-        <button type="button" class="btn btn-secondary" disabled>Monthly</button>
+        <span class="tag tag-neutral" id="mw-header-universe">AAPL · MSFT · SPY · BND · GLD</span>
+        <span class="tag tag-outline" id="mw-header-period">5Y monthly</span>
+        <span class="text-muted" style="font-size: 12px" id="mw-header-status">Not run yet</span>
+        <button type="button" class="btn btn-secondary" id="mw-units-btn">Monthly</button>
     </header>
 
     <div class="mw-shell">
@@ -29,24 +29,24 @@
 
             <div class="card elev-sm">
                 <h6 style="margin: 0; color: var(--color-accent-300)">Universe</h6>
-                <div style="display: flex; flex-wrap: wrap; gap: var(--space-2)">
-                    <button type="button" class="tag mw-chip mw-chip--selected" title="Apple">AAPL</button>
-                    <button type="button" class="tag mw-chip mw-chip--selected" title="Microsoft">MSFT</button>
-                    <button type="button" class="tag mw-chip" title="Alphabet">GOOGL</button>
-                    <button type="button" class="tag mw-chip" title="Amazon">AMZN</button>
-                    <button type="button" class="tag mw-chip" title="NVIDIA">NVDA</button>
-                    <button type="button" class="tag mw-chip mw-chip--selected" title="S&amp;P 500 ETF">SPY</button>
-                    <button type="button" class="tag mw-chip" title="Nasdaq 100 ETF">QQQ</button>
-                    <button type="button" class="tag mw-chip mw-chip--selected" title="Total Bond ETF">BND</button>
-                    <button type="button" class="tag mw-chip mw-chip--selected" title="Gold ETF">GLD</button>
-                    <button type="button" class="tag mw-chip" title="Real Estate ETF">VNQ</button>
+                <div class="mw-chip-row" id="mw-chips">
+                    <button type="button" class="tag mw-chip mw-chip--selected" data-idx="0" title="Apple">AAPL</button>
+                    <button type="button" class="tag mw-chip mw-chip--selected" data-idx="1" title="Microsoft">MSFT</button>
+                    <button type="button" class="tag mw-chip" data-idx="2" title="Alphabet">GOOGL</button>
+                    <button type="button" class="tag mw-chip" data-idx="3" title="Amazon">AMZN</button>
+                    <button type="button" class="tag mw-chip" data-idx="4" title="NVIDIA">NVDA</button>
+                    <button type="button" class="tag mw-chip mw-chip--selected" data-idx="5" title="S&amp;P 500 ETF">SPY</button>
+                    <button type="button" class="tag mw-chip" data-idx="6" title="Nasdaq 100 ETF">QQQ</button>
+                    <button type="button" class="tag mw-chip mw-chip--selected" data-idx="7" title="Total Bond ETF">BND</button>
+                    <button type="button" class="tag mw-chip mw-chip--selected" data-idx="8" title="Gold ETF">GLD</button>
+                    <button type="button" class="tag mw-chip" data-idx="9" title="Real Estate ETF">VNQ</button>
                 </div>
-                <div class="text-muted" style="font-size: 11px">5 of 10 selected · minimum 2</div>
+                <div class="text-muted" style="font-size: 11px" id="mw-chip-count">5 of 10 selected · minimum 2</div>
             </div>
 
             <div class="card elev-sm">
                 <h6 style="margin: 0; color: var(--color-accent-300)">History window</h6>
-                <div class="seg" style="width: 100%">
+                <div class="seg" style="width: 100%" id="mw-period">
                     <label class="seg-opt" style="flex: 1"><input type="radio" name="mwperiod" value="1y">1Y</label>
                     <label class="seg-opt" style="flex: 1"><input type="radio" name="mwperiod" value="2y">2Y</label>
                     <label class="seg-opt" style="flex: 1"><input type="radio" name="mwperiod" value="5y" checked>5Y</label>
@@ -58,12 +58,12 @@
                     <div style="display: flex; gap: var(--space-2); align-items: center">
                         <input id="mwrf" type="range" min="0" max="80" step="5" value="8"
                             style="flex: 1; min-width: 0; accent-color: var(--color-accent); height: 20px" />
-                        <span style="font-family: var(--font-heading); font-size: 14px; min-width: 58px; text-align: right">0.20%</span>
+                        <span style="font-family: var(--font-heading); font-size: 14px; min-width: 58px; text-align: right" id="mwrf-display">0.20%</span>
                     </div>
                 </div>
             </div>
 
-            <button type="button" class="btn btn-primary btn-block" disabled style="height: 38px">Run analysis</button>
+            <button type="button" class="btn btn-primary btn-block" id="mw-run-btn" data-action="run" style="height: 38px">Run analysis</button>
 
             <nav class="mw-toc" aria-label="Report sections">
                 <a href="#frontier">01 Efficient frontier</a>
@@ -82,15 +82,28 @@
         </aside>
 
         <main id="top" class="mw-report">
+            <div id="mw-kpi-slot"></div>
             <div class="card elev-sm mw-placeholder">
                 <span class="card-kicker">Coming soon</span>
                 <p class="card-body">
-                    The report (efficient frontier, allocation, correlation matrix, per-asset statistics and saved
-                    runs) is being rebuilt section by section — see the implementation plan for the staged PRs ahead.
+                    The rest of the report (efficient frontier, allocation, correlation matrix, per-asset statistics
+                    and saved runs) is being rebuilt section by section — see the implementation plan for the staged
+                    PRs ahead.
                 </p>
             </div>
         </main>
     </div>
+
+    <div id="mw-overlay" class="mw-overlay" hidden>
+        <div class="card elev-lg mw-overlay__card">
+            <img src="assets/images/mascote-analise-de-dados.png" alt="" />
+            <div class="mw-spinner"></div>
+            <div class="mw-overlay__title">Solving 60 quadratic programs</div>
+            <div class="text-muted mw-overlay__note" id="mw-overlay-note"></div>
+        </div>
+    </div>
+
+    <script src="app.js"></script>
 </body>
 
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -84,11 +84,12 @@
         <main id="top" class="mw-report">
             <div id="mw-kpi-slot"></div>
             <div id="mw-frontier-slot"></div>
+            <div id="mw-allocation-slot"></div>
             <div class="card elev-sm mw-placeholder">
                 <span class="card-kicker">Coming soon</span>
                 <p class="card-body">
-                    The rest of the report (allocation, correlation matrix, per-asset statistics and saved runs) is
-                    being rebuilt section by section — see the implementation plan for the staged PRs ahead.
+                    The rest of the report (correlation matrix, per-asset statistics and saved runs) is being
+                    rebuilt section by section — see the implementation plan for the staged PRs ahead.
                 </p>
             </div>
         </main>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -83,12 +83,12 @@
 
         <main id="top" class="mw-report">
             <div id="mw-kpi-slot"></div>
+            <div id="mw-frontier-slot"></div>
             <div class="card elev-sm mw-placeholder">
                 <span class="card-kicker">Coming soon</span>
                 <p class="card-body">
-                    The rest of the report (efficient frontier, allocation, correlation matrix, per-asset statistics
-                    and saved runs) is being rebuilt section by section — see the implementation plan for the staged
-                    PRs ahead.
+                    The rest of the report (allocation, correlation matrix, per-asset statistics and saved runs) is
+                    being rebuilt section by section — see the implementation plan for the staged PRs ahead.
                 </p>
             </div>
         </main>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -612,3 +612,90 @@ input[type="range"]:hover::-moz-range-thumb {
   border-top-color: var(--color-accent-400);
   animation: mwspin 0.8s linear infinite;
 }
+
+/* ── Section chrome shared by frontier/allocation/correlation/etc ──────── */
+
+.mw-section-lede {
+  max-width: 70ch;
+  font-size: 14px;
+  margin-bottom: var(--space-6);
+}
+
+/* ── Efficient frontier ──────────────────────────────────────────────── */
+
+.mw-frontier-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  align-items: stretch;
+}
+.mw-frontier-chart-card {
+  flex: 999 1 560px;
+  min-width: 0;
+  padding: var(--space-4);
+}
+.mw-frontier-plot {
+  position: relative;
+  width: 100%;
+}
+.mw-frontier-svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  touch-action: none;
+  cursor: crosshair;
+}
+.mw-frontier-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  font-size: 12.5px;
+  color: var(--color-neutral-400);
+  font-variant-numeric: tabular-nums;
+}
+.mw-frontier-overlay span {
+  position: absolute;
+  white-space: nowrap;
+}
+.mw-frontier-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  padding-top: var(--space-2);
+}
+.mw-frontier-legend .mw-legend-item {
+  font-size: 11.5px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.mw-frontier-stats {
+  flex: 1 1 276px;
+  min-width: 0;
+  gap: var(--space-4);
+  padding: var(--space-4);
+}
+.mw-frontier-stats__title {
+  font-family: var(--font-heading);
+  font-size: 18px;
+  line-height: 1.25;
+  margin-top: var(--space-1);
+}
+.mw-frontier-stats__rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.mw-frontier-stats__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  background: linear-gradient(to right, var(--color-divider), var(--color-divider)) no-repeat bottom /
+    100% 1px;
+  padding-bottom: var(--space-2);
+}
+.mw-frontier-stats__row-value {
+  font-family: var(--font-heading);
+  font-size: 16px;
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -79,6 +79,14 @@
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 14px;
+
+  /* Semantic (outliers-design-system tokens/colors.json) — only --color-error
+     is used so far (analysis-failed states); the rest are here so later PRs
+     don't have to re-derive them. */
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-error: #ef4444;
+  --color-info: #3b82f6;
 }
 
 /* ── Reset & typography ─────────────────────────────────────────────── */
@@ -515,4 +523,92 @@ input[type="range"]:hover::-moz-range-thumb {
   text-align: center;
   gap: var(--space-2);
   padding: var(--space-8);
+}
+
+.mw-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+/* ── KPI band ────────────────────────────────────────────────────────── */
+
+.mw-headline {
+  font-size: clamp(30px, 3.4vw, 40px);
+  margin: 0 0 var(--space-3);
+}
+.mw-lede {
+  max-width: 64ch;
+  font-size: 15px;
+  margin-bottom: var(--space-8);
+}
+.mw-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(168px, 1fr));
+  gap: var(--space-4);
+}
+.mw-kpi-value {
+  font-family: var(--font-heading);
+  font-weight: 500;
+  font-size: clamp(24px, 2.2vw, 31px);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+}
+.mw-kpi-value--accent {
+  color: var(--color-accent-300);
+}
+
+/* ── Error state ─────────────────────────────────────────────────────── */
+
+.mw-error {
+  border: 1px solid color-mix(in srgb, var(--color-error) 35%, transparent);
+}
+.mw-error .card-kicker {
+  color: var(--color-error);
+}
+
+/* ── Running overlay ─────────────────────────────────────────────────── */
+
+.mw-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  background: color-mix(in srgb, var(--color-bg) 82%, transparent);
+}
+/* `.mw-overlay`'s own `display` would otherwise outrank the UA stylesheet's
+   `[hidden]{display:none}` at equal specificity (source order) — pin it
+   explicitly so setting the `hidden` property from JS always wins. */
+.mw-overlay[hidden] {
+  display: none;
+}
+.mw-overlay__card {
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-8);
+  width: min(300px, 86vw);
+}
+.mw-overlay__card img {
+  width: 84px;
+  height: 84px;
+  object-fit: contain;
+}
+.mw-overlay__title {
+  font-family: var(--font-heading);
+  font-size: 14px;
+  text-align: center;
+}
+.mw-overlay__note {
+  font-size: 11.5px;
+  text-align: center;
+}
+.mw-spinner {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 3px solid var(--color-neutral-800);
+  border-top-color: var(--color-accent-400);
+  animation: mwspin 0.8s linear infinite;
 }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -699,3 +699,150 @@ input[type="range"]:hover::-moz-range-thumb {
   font-family: var(--font-heading);
   font-size: 16px;
 }
+
+/* ── Shared "not a <table>" grid rows ────────────────────────────────────
+   Reused by the allocation weights table and (in later PRs) the
+   correlation, per-asset-statistics and saved-runs sections — a header row
+   plus one CSS-grid row per record, each column count/width supplied by the
+   caller via an inline grid-template-columns (they differ per table). */
+
+.mw-table {
+  padding: var(--space-4) 0;
+  overflow-x: auto;
+}
+.mw-table__inner {
+  display: flex;
+  flex-direction: column;
+}
+.mw-grid-row {
+  display: grid;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-6);
+  font-size: 14px;
+}
+.mw-grid-row--head {
+  padding: 0 var(--space-6) var(--space-2);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-neutral-500);
+  background:
+    linear-gradient(
+        to right,
+        transparent,
+        var(--color-divider) 48px,
+        var(--color-divider) calc(100% - 48px),
+        transparent
+      )
+      no-repeat bottom / 100% 1px;
+}
+.mw-grid-row--body {
+  background:
+    linear-gradient(
+        to right,
+        transparent,
+        color-mix(in srgb, var(--color-text) 8%, transparent) 48px,
+        color-mix(in srgb, var(--color-text) 8%, transparent) calc(100% - 48px),
+        transparent
+      )
+      no-repeat bottom / 100% 1px;
+}
+.mw-swatch {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-heading);
+}
+.mw-swatch__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  display: block;
+  flex: none;
+}
+.mw-bar-track {
+  display: block;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--color-neutral-800);
+  overflow: hidden;
+}
+.mw-bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: 3px;
+}
+.mw-num {
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Optimal allocation ──────────────────────────────────────────────── */
+
+.mw-alloc-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  align-items: flex-start;
+}
+.mw-alloc-donut-card {
+  flex: 1 1 232px;
+  align-items: center;
+  padding: var(--space-6);
+}
+.mw-alloc-donut {
+  position: relative;
+  width: 100%;
+  max-width: 210px;
+  aspect-ratio: 1 / 1;
+}
+.mw-alloc-donut svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.mw-alloc-donut__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  pointer-events: none;
+  text-align: center;
+}
+.mw-alloc-donut__value {
+  font-family: var(--font-heading);
+  font-size: clamp(20px, 2vw, 26px);
+  letter-spacing: -0.02em;
+}
+.mw-alloc-donut__note {
+  font-size: 11.5px;
+  text-align: center;
+}
+.mw-alloc-main {
+  flex: 999 1 460px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.mw-cash-card {
+  padding: var(--space-4);
+}
+.mw-cash-card__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+.mw-cash-card__pct {
+  font-family: var(--font-heading);
+  font-size: 15px;
+  color: var(--color-accent-300);
+}
+.mw-cash-card input[type="range"] {
+  width: 100%;
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -846,3 +846,62 @@ input[type="range"]:hover::-moz-range-thumb {
 .mw-cash-card input[type="range"] {
   width: 100%;
 }
+
+/* ── Correlation matrix ──────────────────────────────────────────────── */
+
+.mw-corr-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  align-items: flex-start;
+}
+.mw-corr-matrix-card {
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: var(--space-6);
+  overflow-x: auto;
+}
+.mw-corr-grid {
+  display: grid;
+  justify-content: start;
+  gap: 3px;
+}
+.mw-corr-legend {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+  max-width: 320px;
+}
+.mw-corr-legend__bar {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, var(--color-neutral-900), var(--color-accent-600));
+  display: block;
+}
+.mw-corr-callout {
+  flex: 1 1 300px;
+  max-width: 400px;
+  min-width: 0;
+  padding: var(--space-6);
+  gap: var(--space-3);
+}
+.mw-corr-callout__pair {
+  font-family: var(--font-heading);
+  font-size: 20px;
+  line-height: 1.2;
+}
+.mw-corr-callout__value {
+  font-family: var(--font-heading);
+  font-size: 31px;
+  color: var(--color-accent-300);
+  letter-spacing: -0.02em;
+}
+.mw-corr-callout__footer {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-top: var(--space-2);
+  background: linear-gradient(to right, var(--color-divider), var(--color-divider)) no-repeat top / 100% 1px;
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -905,3 +905,20 @@ input[type="range"]:hover::-moz-range-thumb {
   padding-top: var(--space-2);
   background: linear-gradient(to right, var(--color-divider), var(--color-divider)) no-repeat top / 100% 1px;
 }
+
+/* ── Saved runs ──────────────────────────────────────────────────────── */
+
+.mw-saved-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-6);
+}
+
+.mw-disclaimer {
+  font-size: 11.5px;
+  max-width: 76ch;
+  margin: 0;
+}


### PR DESCRIPTION
## Why this PR exists

PRs #13–17 were stacked (each targeting the previous feature branch, not `main`) and squash-merged in sequence — correctly, cumulatively, all the way up to the `correlation-assets-sections` branch. But the final step, merging that branch up into `frontend-foundation`/`main`, never happened, so none of that work actually reached `main` despite #14–17 showing as "Merged" on GitHub. (#13 also shows "Closed" rather than "Merged" — cosmetic only; its content flowed through via #14's squash onto `control-rail-kpi`, nothing was lost.)

Separately, the branch these PRs were stacked on (`frontend-foundation`) was cut before #11 merged, so it was also missing `asset_statistics`/`min_variance_portfolio` on `AnalyzeResponse` — the same gap I had to patch locally to demo this to you.

This PR is `correlation-assets-sections` (the fully cumulative tip — verified byte-identical to `saved-runs` on `frontend/{app.js,index.html,style.css}`) rebased onto current `main`. Git recognized the `frontend-foundation` commit's content as already upstream (it's PR #12, squash-merged with a different hash) and dropped it automatically — the diff below is exactly the previously-missing PR #13–17 content, nothing duplicated.

## What lands

The complete widescreen report: control rail + KPI band, efficient frontier with drag selection, optimal allocation (donut + cash blend), correlation matrix, per-asset statistics, and saved runs — everything from #13 through #17, described in each of those PRs.

## Verification

`uv run pytest` (27 passed) and `uv run ruff check` (clean) on this exact branch state. Also ran the combined app locally against live `yfinance` data (not mocked) end-to-end before opening this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)