### PR TITLE
Three small fixes: neutral example ticker, rf units bug, trim the rail

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -294,6 +294,17 @@ function renderChips() {
   document.getElementById("mw-chip-count").textContent = `${state.sel.length} selected · minimum 2`;
 }
 
+/** Keeps the risk-free field's label and value in sync with the units
+ * toggle. This used to be updated only from the slider's own `input`
+ * handler, so it went stale the moment you toggled Monthly/Annualized
+ * without also touching the slider — it belongs in the main render loop
+ * like every other unit-dependent display, not off in its own handler. */
+function renderRfControl() {
+  const unitWord = isAnnual() ? "annualized" : "monthly";
+  document.getElementById("mwrf-label").textContent = `Risk-free rate · ${unitWord}`;
+  document.getElementById("mwrf-display").textContent = pct(toReturn(rfOf(state.rfIdx)));
+}
+
 function renderOverlay() {
   const overlay = document.getElementById("mw-overlay");
   overlay.hidden = !state.running;
@@ -1104,6 +1115,7 @@ function renderKpiSlot() {
 function render() {
   renderHeader();
   renderChips();
+  renderRfControl();
   renderOverlay();
   renderKpiSlot();
   renderFrontier();
@@ -1166,8 +1178,7 @@ function init() {
   const rf = document.getElementById("mwrf");
   rf.addEventListener("input", () => {
     state.rfIdx = +rf.value;
-    document.getElementById("mwrf-display").textContent = pct(toReturn(rfOf(state.rfIdx)));
-    render();
+    render(); // updates #mwrf-display too, via renderRfControl()
   });
 
   document.getElementById("mw-units-btn").addEventListener("click", () => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,7 +31,7 @@
                 <h6 style="margin: 0; color: var(--color-accent-300)">Universe</h6>
                 <div class="mw-chip-row" id="mw-chips"></div>
                 <form id="mw-add-ticker-form" class="mw-add-ticker">
-                    <input type="text" id="mw-add-ticker-input" placeholder="Add a ticker (e.g. TSLA)" maxlength="10"
+                    <input type="text" id="mw-add-ticker-input" placeholder="Add a ticker (e.g. SPY)" maxlength="10"
                         autocomplete="off" autocapitalize="characters" spellcheck="false" aria-label="Add a ticker" />
                     <button type="submit" class="btn btn-secondary">Add</button>
                 </form>
@@ -49,7 +49,7 @@
                     <label class="seg-opt" style="flex: 1"><input type="radio" name="mwperiod" value="max">Max</label>
                 </div>
                 <div class="field" style="margin-top: var(--space-3)">
-                    <label for="mwrf">Risk-free rate · monthly</label>
+                    <label for="mwrf" id="mwrf-label">Risk-free rate · monthly</label>
                     <div style="display: flex; gap: var(--space-2); align-items: center">
                         <input id="mwrf" type="range" min="0" max="80" step="5" value="8"
                             style="flex: 1; min-width: 0; accent-color: var(--color-accent); height: 20px" />
@@ -59,20 +59,6 @@
             </div>
 
             <button type="button" class="btn btn-primary btn-block" id="mw-run-btn" data-action="run" style="height: 38px">Run analysis</button>
-
-            <nav class="mw-toc" aria-label="Report sections">
-                <a href="#frontier">01 Efficient frontier</a>
-                <a href="#allocation">02 Optimal allocation</a>
-                <a href="#correlation">03 Correlation matrix</a>
-                <a href="#assets">04 Per-asset statistics</a>
-                <a href="#saved">05 Saved runs</a>
-            </nav>
-
-            <div class="card elev-sm mw-rail-note">
-                <img src="assets/images/mascote-analise-de-dados.png" alt="" />
-                <p class="card-body">Monthly closes over the window, then 60 long-only quadratic programs — one per
-                    level of risk aversion — traced into the frontier below.</p>
-            </div>
 
         </aside>
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -482,34 +482,6 @@ input[type="range"]:hover::-moz-range-thumb {
   }
 }
 
-.mw-rail-note {
-  flex-direction: row;
-  align-items: flex-start;
-  gap: var(--space-3);
-}
-.mw-rail-note img {
-  width: 56px;
-  height: 56px;
-  object-fit: contain;
-  flex: none;
-}
-
-.mw-toc {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-  padding-left: var(--space-2);
-  border-left: 1px solid var(--color-divider);
-}
-.mw-toc a {
-  font-size: 12.5px;
-  padding: 3px 0;
-  color: var(--color-neutral-400);
-}
-.mw-toc a:hover {
-  color: var(--color-accent-300);
-}
-
 .mw-report {
   flex: 999 1 660px;
   min-width: 0;


### PR DESCRIPTION
## Context

Three items from feedback on the live preview. Stacked on #21.

## What changed

- **Example ticker**: placeholder changed from "e.g. TSLA" to "e.g. SPY" — an index ETF rather than a ticker tied to a specific, politically visible individual.
- **Real bug**: toggling Monthly/Annualized never updated the risk-free field's label or value — both were only ever refreshed from the rf slider's own `input` handler, so they went stale the moment you hit the units button without also touching the slider. Moved the update into the main `render()` loop (`renderRfControl()`), where every other unit-dependent display already lives.
- **Rail cleanup**: removed the section TOC (5-item anchor list) and the mascot tip card below Run analysis, per feedback that both were low-value. The rail now ends at the Run button. Report sections keep their `id`s even without a nav pointing at them; the mascot image is still used elsewhere (running overlay, saved-runs empty state, get-started card), so only the now-dead `.mw-toc`/`.mw-rail-note` CSS came out along with the markup.

## Verification

Headless Chromium: placeholder reads "e.g. SPY"; toggling units updates both the rf label and its displayed value correctly in both directions; the TOC and rail note are confirmed gone from the DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)